### PR TITLE
Add graphical database installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,45 @@
 # modPMS
-Ein Modules Hotel Programm
+
+Ein modulares Property-Management-System (PMS) für Hotels, entwickelt in PHP und MySQL. Dieses Repository enthält das Basis-Modul mit Dashboard, Kalender, Zimmerkategorien und integriertem Update-Workflow.
+
+## Features Basis-Modul (Version 1.0.3)
+
+- **Dashboard** mit tagesbasiertem Zimmerkalender (Zimmer auf Y-Achse, Tage auf X-Achse) und Schnellstatistik.
+- **Zimmerkategorien-Verwaltung** mit einfacher JSON-Speicherung (lokal) für einen schnellen Start.
+- **Zimmerübersicht** mit Beispiel-Zimmern, die sich leicht erweitern lassen.
+- **Systemupdates** direkt aus der Weboberfläche via `git` anstoßen.
+- **Installationsassistent** (`public/install.php`) zur grafischen Einrichtung der MySQL-Datenbank inklusive Beispieltabellen.
+- Responsive UI auf Basis von Bootstrap 5.
+
+## Erste Schritte
+
+1. Repository klonen und Abhängigkeiten bereitstellen:
+   ```bash
+   git clone https://github.com/your-org/modPMS.git
+   cd modPMS
+   ```
+2. Das Projektverzeichnis als Webroot (z. B. Apache/Nginx) konfigurieren oder über den integrierten PHP-Server starten:
+   ```bash
+   php -S localhost:8000 -t public
+   ```
+3. Den Installationsassistenten unter <http://localhost:8000/install.php> aufrufen und die MySQL-Datenbank einrichten.
+4. Anschließend das Dashboard öffnen: <http://localhost:8000>
+5. Aus Sicherheitsgründen `public/install.php` nach erfolgreicher Einrichtung entfernen oder sperren.
+
+> **Hinweis:** Für produktive Nutzung sollten Zimmerkategorien und Zimmerstammdaten in einer MySQL-Datenbank persistiert werden. Die JSON-Dateien `storage/room_categories.json` und `storage/rooms.json` sind als leichtgewichtiger Einstieg gedacht.
+
+## Update-Mechanismus
+
+- Die aktuelle Version wird in `config/app.php` geführt. Bitte bei jedem Release anpassen (z. B. 1.0.2, 1.0.3 …).
+- Über den Bereich **Systemupdates** im Dashboard lässt sich per Button ein `git fetch/reset/pull` starten.
+- Voraussetzung ist, dass das System unter einem Git-Checkout läuft und der Webserver Benutzer ausreichende Rechte für `git` besitzt.
+
+## Nächste Module
+
+- Ratenplan & Kalender
+- Putzplan
+- Externe API-Anbindungen
+- Kundenverwaltung
+- Berichte
+
+Feedback & Issues sind jederzeit willkommen!

--- a/config/.gitignore
+++ b/config/.gitignore
@@ -1,0 +1,2 @@
+# Wird vom Installationsassistenten generiert
+/database.php

--- a/config/app.php
+++ b/config/app.php
@@ -1,0 +1,24 @@
+<?php
+
+return [
+    'name' => 'modPMS',
+    'version' => '1.0.3',
+    'repository' => [
+        'url' => 'https://github.com/your-org/modPMS',
+        'branch' => 'main',
+    ],
+    'modules' => [
+        'dashboard' => [
+            'title' => 'Dashboard',
+            'description' => 'Übersicht mit Kalender und Schnellstatistiken.'
+        ],
+        'rooms' => [
+            'title' => 'Zimmerkategorien',
+            'description' => 'Verwaltung von Kategorien, Kapazitäten und Status.'
+        ],
+        'updates' => [
+            'title' => 'Systemupdates',
+            'description' => 'Version anzeigen und Updates aus GitHub abrufen.'
+        ],
+    ],
+];

--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -1,0 +1,92 @@
+body {
+    background-color: #f5f7fa;
+    font-family: 'Inter', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+.navbar-brand {
+    font-weight: 700;
+    letter-spacing: 0.03em;
+}
+
+.module-card {
+    border-radius: 0.75rem;
+    box-shadow: 0 1rem 2rem rgba(15, 23, 42, 0.08);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.module-card:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.12);
+}
+
+.calendar-grid-wrapper {
+    overflow-x: auto;
+}
+
+.room-calendar {
+    min-width: 900px;
+    border-collapse: separate;
+    border-spacing: 0;
+}
+
+.room-calendar th,
+.room-calendar td {
+    text-align: center;
+    vertical-align: middle;
+    white-space: nowrap;
+}
+
+.room-calendar .room-column {
+    min-width: 220px;
+    position: sticky;
+    left: 0;
+    background-color: #f8fafc;
+    box-shadow: inset -1px 0 0 #e2e8f0;
+    z-index: 2;
+}
+
+.room-calendar .room-label {
+    text-align: left;
+    background-color: #fff;
+    position: sticky;
+    left: 0;
+    z-index: 1;
+}
+
+.room-calendar-cell {
+    min-width: 64px;
+    height: 60px;
+    background-color: #f8fafc;
+    transition: background-color 0.2s ease;
+}
+
+.room-calendar-cell:hover {
+    background-color: #e2e8f0;
+}
+
+.room-calendar-cell.today {
+    background-color: #2563eb;
+    color: #fff;
+    position: relative;
+}
+
+.room-calendar-cell.today::after {
+    content: 'Heute';
+    position: absolute;
+    bottom: 6px;
+    right: 6px;
+    font-size: 0.65rem;
+    font-weight: 600;
+    text-transform: uppercase;
+}
+
+.update-output {
+    background: #0f172a;
+    color: #e2e8f0;
+    font-family: 'Fira Code', monospace;
+    font-size: 0.85rem;
+    border-radius: 0.5rem;
+    padding: 1rem;
+    max-height: 220px;
+    overflow-y: auto;
+}

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,251 @@
+<?php
+
+use ModPMS\Calendar;
+use ModPMS\RoomCategoryManager;
+use ModPMS\RoomManager;
+use ModPMS\SystemUpdater;
+
+require_once __DIR__ . '/../src/RoomCategoryManager.php';
+require_once __DIR__ . '/../src/Calendar.php';
+require_once __DIR__ . '/../src/RoomManager.php';
+require_once __DIR__ . '/../src/SystemUpdater.php';
+
+session_start();
+
+$config = require __DIR__ . '/../config/app.php';
+$categoryManager = new RoomCategoryManager(__DIR__ . '/../storage/room_categories.json');
+$categories = $categoryManager->all();
+$roomManager = new RoomManager(__DIR__ . '/../storage/rooms.json');
+$rooms = $roomManager->all();
+
+$calendar = new Calendar();
+$days = $calendar->daysOfMonth();
+
+$alert = null;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['form']) && $_POST['form'] === 'category') {
+    $name = trim($_POST['name'] ?? '');
+    $description = trim($_POST['description'] ?? '');
+    $capacity = (int) ($_POST['capacity'] ?? 0);
+    $status = trim($_POST['status'] ?? 'aktiv');
+
+    if ($name === '' || $capacity <= 0) {
+        $alert = [
+            'type' => 'danger',
+            'message' => 'Bitte geben Sie einen Namen und eine gültige Kapazität an.',
+        ];
+    } else {
+        $categoryManager->add([
+            'name' => $name,
+            'description' => $description,
+            'capacity' => $capacity,
+            'status' => $status,
+        ]);
+
+        $_SESSION['alert'] = [
+            'type' => 'success',
+            'message' => sprintf('Kategorie "%s" erfolgreich angelegt.', htmlspecialchars($name, ENT_QUOTES, 'UTF-8')),
+        ];
+
+        header('Location: index.php');
+        exit;
+    }
+}
+
+if (isset($_SESSION['alert'])) {
+    $alert = $_SESSION['alert'];
+    unset($_SESSION['alert']);
+}
+
+$updater = new SystemUpdater(dirname(__DIR__), $config['repository']['branch']);
+
+?>
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title><?= htmlspecialchars($config['name']) ?> · Basis Modul</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link rel="stylesheet" href="assets/css/style.css">
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-light bg-white shadow-sm">
+      <div class="container">
+        <a class="navbar-brand" href="#">🏨 <?= htmlspecialchars($config['name']) ?></a>
+        <div class="d-flex align-items-center gap-3">
+          <span class="badge rounded-pill text-bg-primary">Version <?= htmlspecialchars($config['version']) ?></span>
+        </div>
+      </div>
+    </nav>
+
+    <main class="container py-5">
+      <?php if ($alert): ?>
+        <div class="alert alert-<?= htmlspecialchars($alert['type']) ?> alert-dismissible fade show" role="alert">
+          <?= $alert['message'] ?>
+          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+      <?php endif; ?>
+
+      <div class="row g-4">
+        <div class="col-lg-8">
+          <div class="card module-card h-100">
+            <div class="card-header bg-transparent border-0 d-flex justify-content-between align-items-center">
+              <div>
+                <h2 class="h5 mb-1">Dashboard</h2>
+                <p class="text-muted mb-0">Kalender und aktuelle Auslastung im Blick.</p>
+              </div>
+              <span class="badge text-bg-info">Basis-Modul</span>
+            </div>
+            <div class="card-body">
+              <div class="d-flex justify-content-between align-items-center mb-3">
+                <h3 class="h4 mb-0"><?= htmlspecialchars($calendar->monthLabel()) ?></h3>
+                <span class="text-muted">Heute: <?= (new DateTime())->format('d.m.Y') ?></span>
+              </div>
+              <div class="calendar-grid-wrapper">
+                <table class="table table-bordered align-middle room-calendar">
+                  <thead class="table-light">
+                    <tr>
+                      <th scope="col" class="room-column">Zimmer</th>
+                      <?php foreach ($days as $day): ?>
+                        <th scope="col" class="text-center">
+                          <div class="day-number"><?= $day['day'] ?></div>
+                          <small class="text-muted text-uppercase"><?= $day['weekday'] ?></small>
+                        </th>
+                      <?php endforeach; ?>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <?php foreach ($rooms as $room): ?>
+                      <tr>
+                        <th scope="row" class="room-label">
+                          <div class="fw-semibold">Zimmer <?= htmlspecialchars($room['number']) ?></div>
+                          <small class="text-muted">Status: <?= htmlspecialchars(ucfirst($room['status'])) ?></small>
+                        </th>
+                        <?php foreach ($days as $day): ?>
+                          <td class="room-calendar-cell <?= $day['isToday'] ? 'today' : '' ?>" data-date="<?= $day['date'] ?>" data-room="<?= htmlspecialchars($room['number']) ?>">
+                            <span class="visually-hidden">Zimmer <?= htmlspecialchars($room['number']) ?> am <?= $day['date'] ?></span>
+                          </td>
+                        <?php endforeach; ?>
+                      </tr>
+                    <?php endforeach; ?>
+                    <?php if (empty($rooms)): ?>
+                      <tr>
+                        <td colspan="<?= count($days) + 1 ?>" class="text-muted text-center py-4">Noch keine Zimmer angelegt.</td>
+                      </tr>
+                    <?php endif; ?>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-4">
+          <div class="card module-card h-100">
+            <div class="card-header bg-transparent border-0">
+              <h2 class="h5 mb-1">Schnellstatistik</h2>
+              <p class="text-muted mb-0">Überblick über Zimmerkategorien.</p>
+            </div>
+            <div class="card-body">
+              <ul class="list-group list-group-flush">
+                <?php foreach ($categories as $category): ?>
+                  <li class="list-group-item d-flex justify-content-between align-items-start">
+                    <div>
+                      <div class="fw-semibold"><?= htmlspecialchars($category['name']) ?></div>
+                      <small class="text-muted">Kapazität: <?= (int) $category['capacity'] ?> Gäste</small>
+                    </div>
+                    <span class="badge <?= $category['status'] === 'aktiv' ? 'text-bg-success' : 'text-bg-secondary' ?>">
+                      <?= htmlspecialchars(ucfirst($category['status'])) ?>
+                    </span>
+                  </li>
+                <?php endforeach; ?>
+                <?php if (empty($categories)): ?>
+                  <li class="list-group-item text-muted">Noch keine Kategorien erfasst.</li>
+                <?php endif; ?>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="row g-4 mt-1">
+        <div class="col-lg-6">
+          <div class="card module-card h-100">
+            <div class="card-header bg-transparent border-0">
+              <h2 class="h5 mb-1">Zimmerkategorien verwalten</h2>
+              <p class="text-muted mb-0">Neue Kategorien für die Belegung anlegen.</p>
+            </div>
+            <div class="card-body">
+              <form method="post" class="row g-3">
+                <input type="hidden" name="form" value="category">
+                <div class="col-12">
+                  <label for="name" class="form-label">Bezeichnung *</label>
+                  <input type="text" class="form-control" id="name" name="name" required>
+                </div>
+                <div class="col-12">
+                  <label for="description" class="form-label">Beschreibung</label>
+                  <textarea class="form-control" id="description" name="description" rows="2"></textarea>
+                </div>
+                <div class="col-md-6">
+                  <label for="capacity" class="form-label">Kapazität *</label>
+                  <input type="number" min="1" class="form-control" id="capacity" name="capacity" required>
+                </div>
+                <div class="col-md-6">
+                  <label for="status" class="form-label">Status</label>
+                  <select class="form-select" id="status" name="status">
+                    <option value="aktiv">Aktiv</option>
+                    <option value="inaktiv">Inaktiv</option>
+                  </select>
+                </div>
+                <div class="col-12 text-end">
+                  <button type="submit" class="btn btn-primary">Kategorie speichern</button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-6">
+          <div class="card module-card h-100">
+            <div class="card-header bg-transparent border-0 d-flex justify-content-between align-items-center">
+              <div>
+                <h2 class="h5 mb-1">Systemupdates</h2>
+                <p class="text-muted mb-0">Aktuelle Version prüfen und GitHub-Updates abrufen.</p>
+              </div>
+              <span class="badge text-bg-secondary">Update</span>
+            </div>
+            <div class="card-body">
+              <p class="mb-2">Repository: <code><?= htmlspecialchars($config['repository']['url']) ?></code></p>
+              <p>Branch: <code><?= htmlspecialchars($config['repository']['branch']) ?></code></p>
+              <form action="update.php" method="post" class="d-flex flex-column gap-3">
+                <input type="hidden" name="token" value="<?= htmlspecialchars($_SESSION['update_token'] = bin2hex(random_bytes(16))) ?>">
+                <button type="submit" class="btn btn-outline-primary">Update jetzt starten</button>
+              </form>
+              <div class="mt-4">
+                <h3 class="h6 text-muted">Letzte Update-Ausgabe</h3>
+                <?php if (isset($_SESSION['update_output'])): ?>
+                  <div class="update-output">
+                    <?php foreach ($_SESSION['update_output'] as $line): ?>
+                      <div><?= htmlspecialchars($line) ?></div>
+                    <?php endforeach; ?>
+                  </div>
+                  <?php unset($_SESSION['update_output']); ?>
+                <?php else: ?>
+                  <p class="text-muted mb-0">Noch keine Updates ausgeführt.</p>
+                <?php endif; ?>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+
+    <footer class="py-4 bg-white border-top mt-5">
+      <div class="container d-flex flex-column flex-md-row justify-content-between align-items-center text-muted">
+        <small>&copy; <?= date('Y') ?> <?= htmlspecialchars($config['name']) ?>. Alle Rechte vorbehalten.</small>
+        <small>Basis-Version <?= htmlspecialchars($config['version']) ?> · Modulstatus: Aktiv</small>
+      </div>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+  </body>
+</html>

--- a/public/install.php
+++ b/public/install.php
@@ -1,0 +1,356 @@
+<?php
+
+session_start();
+
+$config = require __DIR__ . '/../config/app.php';
+$databaseConfigPath = __DIR__ . '/../config/database.php';
+$existingDatabaseConfig = is_readable($databaseConfigPath) ? include $databaseConfigPath : null;
+if ($existingDatabaseConfig !== null && !is_array($existingDatabaseConfig)) {
+    $existingDatabaseConfig = null;
+}
+$configDirectory = dirname($databaseConfigPath);
+
+$step = isset($_GET['step']) ? max(1, min(3, (int) $_GET['step'])) : 1;
+$errors = [];
+$successData = $_SESSION['install_success'] ?? null;
+if ($successData) {
+    unset($_SESSION['install_success']);
+}
+
+$requirements = [
+    'phpVersion' => version_compare(PHP_VERSION, '8.1.0', '>='),
+    'pdoExtension' => extension_loaded('pdo_mysql'),
+    'configWritable' => $existingDatabaseConfig ? is_writable($databaseConfigPath) : is_writable($configDirectory),
+    'configExists' => (bool) $existingDatabaseConfig,
+];
+
+$configWritableLabel = $requirements['configExists']
+    ? 'Schreibrechte für <code>config/database.php</code>'
+    : 'Schreibrechte für <code>config/</code>';
+$configWritableDescription = $requirements['configExists']
+    ? 'Erforderlich, um die bestehende Konfiguration zu aktualisieren.'
+    : 'Erforderlich, um <code>database.php</code> anzulegen.';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $currentStep = (int) ($_POST['step'] ?? 1);
+
+    if ($currentStep === 1 && $requirements['phpVersion'] && $requirements['pdoExtension'] && $requirements['configWritable']) {
+        header('Location: install.php?step=2');
+        exit;
+    }
+
+    if ($currentStep === 2) {
+        $dbHost = trim($_POST['db_host'] ?? '');
+        $dbPort = trim($_POST['db_port'] ?? '3306');
+        $dbName = trim($_POST['db_name'] ?? '');
+        $dbUser = trim($_POST['db_user'] ?? '');
+        $dbPassword = $_POST['db_password'] ?? '';
+        $createDatabase = isset($_POST['create_database']);
+
+        if ($dbHost === '' || $dbName === '' || $dbUser === '') {
+            $errors[] = 'Bitte füllen Sie alle Pflichtfelder aus.';
+        }
+
+        if ($dbName !== '' && !preg_match('/^[A-Za-z0-9_]+$/', $dbName)) {
+            $errors[] = 'Der Datenbankname darf nur Buchstaben, Zahlen und Unterstriche enthalten.';
+        }
+
+        if ($dbPort !== '' && !preg_match('/^[0-9]+$/', $dbPort)) {
+            $errors[] = 'Der Port darf nur Ziffern enthalten.';
+        }
+
+        if (!$errors) {
+            try {
+                $dsn = sprintf('mysql:host=%s;port=%s;charset=utf8mb4', $dbHost, $dbPort !== '' ? $dbPort : '3306');
+                $pdo = new PDO($dsn, $dbUser, $dbPassword, [
+                    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+                ]);
+
+                if ($createDatabase) {
+                    $pdo->exec(sprintf('CREATE DATABASE IF NOT EXISTS `%s` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci', str_replace('`', '', $dbName)));
+                }
+
+                $pdo->exec(sprintf('USE `%s`', str_replace('`', '', $dbName)));
+
+                $pdo->exec('CREATE TABLE IF NOT EXISTS room_categories (
+                    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                    name VARCHAR(150) NOT NULL,
+                    description TEXT NULL,
+                    capacity INT UNSIGNED NOT NULL DEFAULT 1,
+                    status ENUM("aktiv", "inaktiv") NOT NULL DEFAULT "aktiv",
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci');
+
+                $pdo->exec('CREATE TABLE IF NOT EXISTS rooms (
+                    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                    room_number VARCHAR(20) NOT NULL,
+                    category_id INT UNSIGNED NULL,
+                    status ENUM("frei", "belegt", "wartung") NOT NULL DEFAULT "frei",
+                    floor VARCHAR(50) NULL,
+                    notes TEXT NULL,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                    CONSTRAINT fk_rooms_category FOREIGN KEY (category_id) REFERENCES room_categories(id) ON DELETE SET NULL
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci');
+
+                $seedCategory = $pdo->query('SELECT COUNT(*) AS total FROM room_categories')->fetchColumn();
+                if ((int) $seedCategory === 0) {
+                    $stmt = $pdo->prepare('INSERT INTO room_categories (name, description, capacity, status) VALUES (?, ?, ?, ?)');
+                    $stmt->execute(['Standardzimmer', 'Komfortable Zimmer mit Queen-Size-Bett', 2, 'aktiv']);
+                    $stmt->execute(['Deluxe Suite', 'Großzügige Suite mit Wohnbereich', 4, 'aktiv']);
+                }
+
+                $seedRooms = $pdo->query('SELECT COUNT(*) AS total FROM rooms')->fetchColumn();
+                if ((int) $seedRooms === 0) {
+                    $stmt = $pdo->prepare('INSERT INTO rooms (room_number, category_id, status, floor) VALUES (?, ?, ?, ?)');
+                    $stmt->execute(['101', 1, 'frei', '1']);
+                    $stmt->execute(['102', 1, 'belegt', '1']);
+                    $stmt->execute(['201', 2, 'frei', '2']);
+                }
+
+                $databaseConfig = [
+                    'driver' => 'mysql',
+                    'host' => $dbHost,
+                    'port' => $dbPort,
+                    'database' => $dbName,
+                    'username' => $dbUser,
+                    'password' => $dbPassword,
+                    'charset' => 'utf8mb4',
+                    'collation' => 'utf8mb4_unicode_ci',
+                ];
+
+                $configContent = "<?php\n\nreturn " . var_export($databaseConfig, true) . ";\n";
+
+                if (false === file_put_contents($databaseConfigPath, $configContent)) {
+                    throw new RuntimeException('Die Konfigurationsdatei konnte nicht geschrieben werden.');
+                }
+
+                $_SESSION['install_success'] = [
+                    'database' => $dbName,
+                    'host' => $dbHost,
+                    'port' => $dbPort,
+                ];
+
+                header('Location: install.php?step=3');
+                exit;
+            } catch (Throwable $exception) {
+                $errors[] = $exception->getMessage();
+            }
+        }
+
+        $step = 2;
+    }
+}
+
+if ($step === 3 && !$successData) {
+    $step = 1;
+}
+
+?>
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Installation · <?= htmlspecialchars($config['name']) ?></title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <style>
+      body {
+        min-height: 100vh;
+        background: linear-gradient(135deg, #f8fafc 0%, #eef2ff 100%);
+      }
+      .install-card {
+        border: none;
+        border-radius: 1rem;
+        box-shadow: 0 20px 45px rgba(15, 23, 42, 0.15);
+      }
+      .step-badge {
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: 600;
+      }
+      .requirement-item {
+        border-radius: 0.75rem;
+        border: 1px solid rgba(15, 23, 42, 0.08);
+        padding: 1rem;
+        background: #fff;
+      }
+    </style>
+  </head>
+  <body class="d-flex align-items-center py-5">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-lg-8 col-xl-7">
+          <div class="card install-card">
+            <div class="card-body p-5">
+              <div class="d-flex justify-content-between align-items-center mb-4">
+                <div>
+                  <h1 class="h3 mb-1">Installation · <?= htmlspecialchars($config['name']) ?></h1>
+                  <p class="text-muted mb-0">Grafischer Assistent zur Einrichtung der Datenbank.</p>
+                </div>
+                <span class="badge text-bg-primary">Version <?= htmlspecialchars($config['version']) ?></span>
+              </div>
+
+              <?php if ($errors): ?>
+                <div class="alert alert-danger">
+                  <h2 class="h6 mb-2">Es sind Fehler aufgetreten:</h2>
+                  <ul class="mb-0">
+                    <?php foreach ($errors as $error): ?>
+                      <li><?= htmlspecialchars($error) ?></li>
+                    <?php endforeach; ?>
+                  </ul>
+                </div>
+              <?php endif; ?>
+
+              <?php if ($step === 1): ?>
+                <form method="post" class="d-flex flex-column gap-4">
+                  <input type="hidden" name="step" value="1">
+                  <div class="d-flex align-items-center gap-3">
+                    <div class="step-badge bg-primary text-white">1</div>
+                    <div>
+                      <h2 class="h5 mb-1">Systemprüfung</h2>
+                      <p class="text-muted mb-0">Wir prüfen, ob Ihr Server die Mindestanforderungen erfüllt.</p>
+                    </div>
+                  </div>
+
+                  <div class="d-grid gap-3">
+                    <div class="requirement-item d-flex justify-content-between align-items-center">
+                      <div>
+                        <strong>PHP-Version ≥ 8.1</strong>
+                        <p class="text-muted mb-0">Aktuelle Version: <?= PHP_VERSION ?></p>
+                      </div>
+                      <span class="badge <?= $requirements['phpVersion'] ? 'text-bg-success' : 'text-bg-danger' ?>">
+                        <?= $requirements['phpVersion'] ? 'OK' : 'Nicht erfüllt' ?>
+                      </span>
+                    </div>
+                    <div class="requirement-item d-flex justify-content-between align-items-center">
+                      <div>
+                        <strong>PDO MySQL Erweiterung</strong>
+                        <p class="text-muted mb-0">Benötigt für die Datenbankverbindung.</p>
+                      </div>
+                      <span class="badge <?= $requirements['pdoExtension'] ? 'text-bg-success' : 'text-bg-danger' ?>">
+                        <?= $requirements['pdoExtension'] ? 'Aktiv' : 'Fehlt' ?>
+                      </span>
+                    </div>
+                    <div class="requirement-item d-flex justify-content-between align-items-center">
+                      <div>
+                        <strong><?= $configWritableLabel ?></strong>
+                        <p class="text-muted mb-0"><?= $configWritableDescription ?></p>
+                      </div>
+                      <span class="badge <?= $requirements['configWritable'] ? 'text-bg-success' : 'text-bg-danger' ?>">
+                        <?= $requirements['configWritable'] ? 'Beschreibbar' : 'Keine Rechte' ?>
+                      </span>
+                    </div>
+                  </div>
+
+                  <?php if ($requirements['configExists']): ?>
+                    <div class="alert alert-warning mb-0">
+                      <strong>Hinweis:</strong> Eine bestehende <code>config/database.php</code> wurde gefunden. Bei der erneuten Installation wird diese Datei überschrieben.
+                    </div>
+                  <?php endif; ?>
+
+                  <div class="d-flex justify-content-end">
+                    <button type="submit" class="btn btn-primary" <?= ($requirements['phpVersion'] && $requirements['pdoExtension'] && $requirements['configWritable']) ? '' : 'disabled' ?>>Weiter zu Schritt 2</button>
+                  </div>
+                </form>
+              <?php elseif ($step === 2): ?>
+                <?php
+                  $prefill = [
+                      'host' => $_POST['db_host'] ?? ($existingDatabaseConfig['host'] ?? 'localhost'),
+                      'port' => $_POST['db_port'] ?? ($existingDatabaseConfig['port'] ?? '3306'),
+                      'name' => $_POST['db_name'] ?? ($existingDatabaseConfig['database'] ?? $config['name']),
+                      'user' => $_POST['db_user'] ?? ($existingDatabaseConfig['username'] ?? ''),
+                  ];
+                ?>
+                <form method="post" class="d-flex flex-column gap-4">
+                  <input type="hidden" name="step" value="2">
+
+                  <div class="d-flex align-items-center gap-3">
+                    <div class="step-badge bg-primary text-white">2</div>
+                    <div>
+                      <h2 class="h5 mb-1">Datenbank konfigurieren</h2>
+                      <p class="text-muted mb-0">Bitte geben Sie Ihre MySQL-Zugangsdaten ein.</p>
+                    </div>
+                  </div>
+
+                  <?php if ($requirements['configExists']): ?>
+                    <div class="alert alert-info mb-0">
+                      Die bestehenden Verbindungsdaten wurden vorausgefüllt. Änderungen werden in <code>config/database.php</code> gespeichert.
+                    </div>
+                  <?php endif; ?>
+
+                  <div class="row g-3">
+                    <div class="col-md-6">
+                      <label for="db_host" class="form-label">Host *</label>
+                      <input type="text" class="form-control" id="db_host" name="db_host" value="<?= htmlspecialchars($prefill['host']) ?>" required>
+                    </div>
+                    <div class="col-md-6">
+                      <label for="db_port" class="form-label">Port</label>
+                      <input type="text" class="form-control" id="db_port" name="db_port" value="<?= htmlspecialchars($prefill['port']) ?>">
+                    </div>
+                    <div class="col-md-6">
+                      <label for="db_name" class="form-label">Datenbankname *</label>
+                      <input type="text" class="form-control" id="db_name" name="db_name" value="<?= htmlspecialchars($prefill['name']) ?>" required>
+                    </div>
+                    <div class="col-md-6">
+                      <label for="db_user" class="form-label">Benutzer *</label>
+                      <input type="text" class="form-control" id="db_user" name="db_user" value="<?= htmlspecialchars($prefill['user']) ?>" required>
+                    </div>
+                    <div class="col-12">
+                      <label for="db_password" class="form-label">Passwort</label>
+                      <input type="password" class="form-control" id="db_password" name="db_password" value="<?= htmlspecialchars($_POST['db_password'] ?? '') ?>">
+                    </div>
+                    <div class="col-12">
+                      <div class="form-check">
+                        <input class="form-check-input" type="checkbox" value="1" id="create_database" name="create_database" <?= isset($_POST['create_database']) ? 'checked' : '' ?>>
+                        <label class="form-check-label" for="create_database">
+                          Datenbank automatisch anlegen (falls nicht vorhanden)
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="d-flex justify-content-between">
+                    <a class="btn btn-link" href="install.php?step=1">Zurück</a>
+                    <button type="submit" class="btn btn-primary">Installation starten</button>
+                  </div>
+                </form>
+              <?php elseif ($step === 3 && $successData): ?>
+                <div class="d-flex align-items-center gap-3 mb-4">
+                  <div class="step-badge bg-success text-white">3</div>
+                  <div>
+                    <h2 class="h5 mb-1">Installation abgeschlossen</h2>
+                    <p class="text-muted mb-0">Ihre Datenbank wurde erfolgreich eingerichtet.</p>
+                  </div>
+                </div>
+
+                <div class="alert alert-success">
+                  <h2 class="h6 mb-2">Verbindung hergestellt</h2>
+                  <p class="mb-0">Die Datenbank <strong><?= htmlspecialchars($successData['database']) ?></strong> auf <strong><?= htmlspecialchars($successData['host']) ?><?= $successData['port'] ? ':' . htmlspecialchars($successData['port']) : '' ?></strong> wurde konfiguriert. Sie können sich jetzt im Dashboard anmelden.</p>
+                </div>
+
+                <div class="card border-0 shadow-sm">
+                  <div class="card-body">
+                    <h3 class="h6 text-uppercase text-muted mb-3">Nächste Schritte</h3>
+                    <ul class="mb-4">
+                      <li>Überprüfen Sie die generierte Datei <code>config/database.php</code> und passen Sie sie bei Bedarf an.</li>
+                      <li>Entfernen oder sichern Sie <code>public/install.php</code>, um unbefugte Zugriffe zu verhindern.</li>
+                      <li>Melden Sie sich am <a href="index.php">Dashboard</a> an und beginnen Sie mit der Konfiguration.</li>
+                    </ul>
+                    <a href="index.php" class="btn btn-success">Zum Dashboard</a>
+                  </div>
+                </div>
+              <?php endif; ?>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/public/update.php
+++ b/public/update.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use ModPMS\SystemUpdater;
+
+require_once __DIR__ . '/../src/SystemUpdater.php';
+
+session_start();
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo 'Methode nicht erlaubt';
+    exit;
+}
+
+if (!isset($_POST['token'], $_SESSION['update_token']) || !hash_equals($_SESSION['update_token'], $_POST['token'])) {
+    http_response_code(400);
+    echo 'Ungültiger Token';
+    exit;
+}
+
+$config = require __DIR__ . '/../config/app.php';
+$updater = new SystemUpdater(dirname(__DIR__), $config['repository']['branch']);
+
+$result = $updater->performUpdate();
+
+$log = [$result['message']];
+if (isset($result['details'])) {
+    foreach ($result['details'] as $detail) {
+        $log[] = sprintf('> %s (Status: %d)', $detail['command'], $detail['status']);
+        foreach ($detail['output'] as $line) {
+            $log[] = '  ' . $line;
+        }
+    }
+}
+
+$_SESSION['update_output'] = $log;
+$_SESSION['alert'] = [
+    'type' => $result['success'] ? 'success' : 'danger',
+    'message' => $result['message'],
+];
+
+header('Location: index.php');
+exit;

--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace ModPMS;
+
+use DateTimeImmutable;
+use IntlDateFormatter;
+
+class Calendar
+{
+    private DateTimeImmutable $currentDate;
+
+    public function __construct(?DateTimeImmutable $date = null)
+    {
+        $this->currentDate = $date ?? new DateTimeImmutable('first day of this month');
+    }
+
+    public function monthLabel(): string
+    {
+        $formatter = new IntlDateFormatter(
+            'de_DE',
+            IntlDateFormatter::LONG,
+            IntlDateFormatter::NONE,
+            $this->currentDate->getTimezone()->getName(),
+            IntlDateFormatter::GREGORIAN,
+            'LLLL yyyy'
+        );
+
+        return $formatter->format($this->currentDate) ?: $this->currentDate->format('F Y');
+    }
+
+    /**
+     * @return array<int, array<int, array<string, int|string|bool>>>
+     */
+    public function weeks(): array
+    {
+        $start = $this->currentDate->modify('last monday');
+        $weeks = [];
+
+        for ($week = 0; $week < 6; $week++) {
+            $weekDays = [];
+            for ($day = 0; $day < 7; $day++) {
+                $date = $start->modify(sprintf('+%d days', $week * 7 + $day));
+                $weekDays[] = [
+                    'day' => (int) $date->format('j'),
+                    'isCurrentMonth' => $date->format('m') === $this->currentDate->format('m'),
+                    'isToday' => $date->format('Y-m-d') === (new DateTimeImmutable())->format('Y-m-d'),
+                    'fullDate' => $date->format('Y-m-d'),
+                ];
+            }
+            $weeks[] = $weekDays;
+        }
+
+        return $weeks;
+    }
+
+    /**
+     * @return array<int, array<string, int|string|bool>>
+     */
+    public function daysOfMonth(): array
+    {
+        $days = [];
+        $daysInMonth = (int) $this->currentDate->format('t');
+        $weekdayFormatter = new IntlDateFormatter(
+            'de_DE',
+            IntlDateFormatter::NONE,
+            IntlDateFormatter::NONE,
+            $this->currentDate->getTimezone()->getName(),
+            IntlDateFormatter::GREGORIAN,
+            'EE'
+        );
+
+        for ($offset = 0; $offset < $daysInMonth; $offset++) {
+            $date = $this->currentDate->modify(sprintf('+%d days', $offset));
+
+            $days[] = [
+                'day' => (int) $date->format('j'),
+                'weekday' => $weekdayFormatter->format($date) ?: $date->format('D'),
+                'isToday' => $date->format('Y-m-d') === (new DateTimeImmutable())->format('Y-m-d'),
+                'date' => $date->format('Y-m-d'),
+            ];
+        }
+
+        return $days;
+    }
+}

--- a/src/RoomCategoryManager.php
+++ b/src/RoomCategoryManager.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace ModPMS;
+
+class RoomCategoryManager
+{
+    private string $storageFile;
+
+    public function __construct(string $storageFile)
+    {
+        $this->storageFile = $storageFile;
+        if (!file_exists($storageFile)) {
+            $this->persist([]);
+        }
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function all(): array
+    {
+        $raw = file_get_contents($this->storageFile);
+        if ($raw === false || $raw === '') {
+            return [];
+        }
+
+        $data = json_decode($raw, true);
+
+        return is_array($data) ? $data : [];
+    }
+
+    /**
+     * @param array<string, mixed> $category
+     */
+    public function add(array $category): void
+    {
+        $categories = $this->all();
+        $category['id'] = $this->generateId($categories);
+        $categories[] = $category;
+        $this->persist($categories);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $categories
+     */
+    private function persist(array $categories): void
+    {
+        $payload = json_encode($categories, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+        file_put_contents($this->storageFile, $payload . PHP_EOL);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $categories
+     */
+    private function generateId(array $categories): int
+    {
+        if (empty($categories)) {
+            return 1;
+        }
+
+        $ids = array_column($categories, 'id');
+        $max = max($ids);
+
+        return is_numeric($max) ? ((int) $max + 1) : 1;
+    }
+}

--- a/src/RoomManager.php
+++ b/src/RoomManager.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace ModPMS;
+
+class RoomManager
+{
+    private string $storagePath;
+
+    public function __construct(string $storagePath)
+    {
+        $this->storagePath = $storagePath;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function all(): array
+    {
+        if (!file_exists($this->storagePath)) {
+            return [];
+        }
+
+        $content = file_get_contents($this->storagePath);
+
+        if ($content === false || $content === '') {
+            return [];
+        }
+
+        $data = json_decode($content, true);
+
+        return is_array($data) ? $data : [];
+    }
+}

--- a/src/SystemUpdater.php
+++ b/src/SystemUpdater.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace ModPMS;
+
+class SystemUpdater
+{
+    private string $projectRoot;
+    private string $branch;
+
+    public function __construct(string $projectRoot, string $branch = 'main')
+    {
+        $this->projectRoot = $projectRoot;
+        $this->branch = $branch;
+    }
+
+    public function gitAvailable(): bool
+    {
+        $output = null;
+        $result = null;
+        @exec('which git', $output, $result);
+
+        return $result === 0 && !empty($output);
+    }
+
+    public function performUpdate(): array
+    {
+        if (!$this->gitAvailable()) {
+            return [
+                'success' => false,
+                'message' => 'Git ist auf dem Server nicht verfügbar. Bitte manuell aktualisieren.',
+            ];
+        }
+
+        $branch = $this->sanitizeBranch($this->branch);
+        if ($branch === null) {
+            return [
+                'success' => false,
+                'message' => 'Ungültiger Branch-Name für Updates.',
+            ];
+        }
+
+        $commands = [
+            'git fetch --all',
+            sprintf('git reset --hard origin/%s', $branch),
+            sprintf('git pull origin %s', $branch),
+        ];
+
+        $output = [];
+        foreach ($commands as $command) {
+            $cmdOutput = [];
+            $status = 0;
+            exec(sprintf('cd %s && %s', escapeshellarg($this->projectRoot), $command), $cmdOutput, $status);
+            $output[] = [
+                'command' => $command,
+                'status' => $status,
+                'output' => $cmdOutput,
+            ];
+
+            if ($status !== 0) {
+                return [
+                    'success' => false,
+                    'message' => 'Update fehlgeschlagen. Siehe Details.',
+                    'details' => $output,
+                ];
+            }
+        }
+
+        return [
+            'success' => true,
+            'message' => 'Update erfolgreich durchgeführt.',
+            'details' => $output,
+        ];
+    }
+
+    private function sanitizeBranch(string $branch): ?string
+    {
+        if ($branch === '') {
+            return null;
+        }
+
+        if (!preg_match('/^[A-Za-z0-9._\-\/]+$/', $branch)) {
+            return null;
+        }
+
+        return $branch;
+    }
+}

--- a/storage/room_categories.json
+++ b/storage/room_categories.json
@@ -1,0 +1,16 @@
+[
+    {
+        "id": 1,
+        "name": "Standard Doppelzimmer",
+        "description": "Gemütliches Doppelzimmer mit Queensize-Bett.",
+        "capacity": 2,
+        "status": "aktiv"
+    },
+    {
+        "id": 2,
+        "name": "Deluxe Suite",
+        "description": "Großzügige Suite mit Wohnzimmer und Balkon.",
+        "capacity": 4,
+        "status": "aktiv"
+    }
+]

--- a/storage/rooms.json
+++ b/storage/rooms.json
@@ -1,0 +1,23 @@
+[
+    {
+        "id": 101,
+        "number": "101",
+        "category_id": 1,
+        "name": "Standard Doppelzimmer 101",
+        "status": "frei"
+    },
+    {
+        "id": 102,
+        "number": "102",
+        "category_id": 1,
+        "name": "Standard Doppelzimmer 102",
+        "status": "belegt"
+    },
+    {
+        "id": 201,
+        "number": "201",
+        "category_id": 2,
+        "name": "Deluxe Suite 201",
+        "status": "frei"
+    }
+]


### PR DESCRIPTION
## Summary
- add a Bootstrap-based installation wizard that guides through database checks, credential entry, schema setup, and config generation
- prefill existing database credentials when re-running the installer and guard overwriting config/database.php
- document the new installer in the README, ignore the generated database config, and bump the app version to 1.0.3

## Testing
- php -l public/install.php
- php -l config/app.php

------
https://chatgpt.com/codex/tasks/task_e_68f4d03f15ec8333b9be7ac7180b7341