### PR TITLE
Add graphical database installer (secure update endpoint)

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -7,6 +7,11 @@ return [
         'url' => 'https://github.com/your-org/modPMS',
         'branch' => 'main',
     ],
+    'update_guard' => [
+        'enabled' => false,
+        'username' => null,
+        'password_hash' => null,
+    ],
     'modules' => [
         'dashboard' => [
             'title' => 'Dashboard',


### PR DESCRIPTION
## Summary
- add a Bootstrap-based installation wizard that guides through database checks, credential entry, schema setup, and config generation
- prefill existing database credentials when re-running the installer and guard overwriting config/database.php
- document the new installer in the README, ignore the generated database config, and bump the app version to 1.0.3
- protect the system update endpoint behind configurable admin authentication and disable it by default

## Testing
- php -l config/app.php
- php -l public/index.php
- php -l public/update.php

------
https://chatgpt.com/codex/tasks/task_e_68f50ef3b9f48333993b8c9f23825e61