### PR TITLE
Harden updater when Git metadata is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,45 @@
 # modPMS
-Ein Modules Hotel Programm
+
+Ein modulares Property-Management-System (PMS) für Hotels, entwickelt in PHP und MySQL. Dieses Repository enthält das Basis-Modul mit Dashboard, Kalender, Zimmerkategorien und integriertem Update-Workflow.
+
+## Features Basis-Modul (Version 1.0.8)
+
+- **Dashboard** mit tagesbasiertem Zimmerkalender (Zimmer auf Y-Achse, Tage auf X-Achse) und Schnellstatistik.
+- **Zimmerkategorien-Verwaltung** inklusive Bearbeiten/Löschen und **Zimmerstamm** mit CRUD-Funktionen – alles direkt in MySQL gespeichert.
+- **Zimmerübersicht** mit Beispielzimmern aus der Datenbank, die sich leicht erweitern lassen.
+- **Systemupdates** direkt aus der Weboberfläche via `git` anstoßen – inklusive Repository-Prüfungen und aussagekräftigen Fehlermeldungen.
+- **Installationsassistent** (`public/install.php`) zur grafischen Einrichtung der MySQL-Datenbank inklusive Beispieltabellen.
+- Responsive UI auf Basis von Bootstrap 5.
+
+## Erste Schritte
+
+1. Repository klonen und Abhängigkeiten bereitstellen:
+   ```bash
+   git clone https://github.com/rinkelzz/modpms.git
+   cd modPMS
+   ```
+2. Das Projektverzeichnis als Webroot (z. B. Apache/Nginx) konfigurieren oder über den integrierten PHP-Server starten:
+   ```bash
+   php -S localhost:8000 -t public
+   ```
+3. Den Installationsassistenten unter <http://localhost:8000/install.php> aufrufen und die MySQL-Datenbank einrichten.
+4. Anschließend das Dashboard öffnen: <http://localhost:8000>
+5. Aus Sicherheitsgründen `public/install.php` nach erfolgreicher Einrichtung entfernen oder sperren.
+
+> **Hinweis:** Nach der Installation werden Zimmerkategorien und Zimmer direkt in der konfigurierten MySQL-Datenbank gespeichert. Passen Sie die Zugangsdaten bei Bedarf in `config/database.php` an.
+
+## Update-Mechanismus
+
+- Die aktuelle Version wird in `config/app.php` geführt. Bitte bei jedem Release anpassen (z. B. 1.0.2, 1.0.3 …).
+- Über den Bereich **Systemupdates** im Dashboard lässt sich per Button ein `git fetch/reset/pull` starten. Die Remote-URL wird dabei automatisch auf `https://github.com/rinkelzz/modpms` gesetzt oder – falls noch kein Remote existiert – initial hinterlegt.
+- Voraussetzung ist, dass das System unter einem Git-Checkout läuft, `.git` verfügbar ist und der Webserver-Benutzer ausreichende Rechte für `git` besitzt. Andernfalls liefert der Updater nun eine klare Fehlermeldung.
+
+## Nächste Module
+
+- Ratenplan & Kalender
+- Putzplan
+- Externe API-Anbindungen
+- Kundenverwaltung
+- Berichte
+
+Feedback & Issues sind jederzeit willkommen!

--- a/config/.gitignore
+++ b/config/.gitignore
@@ -1,0 +1,2 @@
+# Wird vom Installationsassistenten generiert
+/database.php

--- a/config/app.php
+++ b/config/app.php
@@ -1,0 +1,24 @@
+<?php
+
+return [
+    'name' => 'modPMS',
+    'version' => '1.0.8',
+    'repository' => [
+        'url' => 'https://github.com/rinkelzz/modpms',
+        'branch' => 'main',
+    ],
+    'modules' => [
+        'dashboard' => [
+            'title' => 'Dashboard',
+            'description' => 'Übersicht mit Kalender und Schnellstatistiken.'
+        ],
+        'rooms' => [
+            'title' => 'Zimmerkategorien',
+            'description' => 'Verwaltung von Kategorien, Kapazitäten und Status.'
+        ],
+        'updates' => [
+            'title' => 'Systemupdates',
+            'description' => 'Version anzeigen und Updates aus GitHub abrufen.'
+        ],
+    ],
+];

--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -1,0 +1,92 @@
+body {
+    background-color: #f5f7fa;
+    font-family: 'Inter', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
+
+.navbar-brand {
+    font-weight: 700;
+    letter-spacing: 0.03em;
+}
+
+.module-card {
+    border-radius: 0.75rem;
+    box-shadow: 0 1rem 2rem rgba(15, 23, 42, 0.08);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.module-card:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.12);
+}
+
+.calendar-grid-wrapper {
+    overflow-x: auto;
+}
+
+.room-calendar {
+    min-width: 900px;
+    border-collapse: separate;
+    border-spacing: 0;
+}
+
+.room-calendar th,
+.room-calendar td {
+    text-align: center;
+    vertical-align: middle;
+    white-space: nowrap;
+}
+
+.room-calendar .room-column {
+    min-width: 220px;
+    position: sticky;
+    left: 0;
+    background-color: #f8fafc;
+    box-shadow: inset -1px 0 0 #e2e8f0;
+    z-index: 2;
+}
+
+.room-calendar .room-label {
+    text-align: left;
+    background-color: #fff;
+    position: sticky;
+    left: 0;
+    z-index: 1;
+}
+
+.room-calendar-cell {
+    min-width: 64px;
+    height: 60px;
+    background-color: #f8fafc;
+    transition: background-color 0.2s ease;
+}
+
+.room-calendar-cell:hover {
+    background-color: #e2e8f0;
+}
+
+.room-calendar-cell.today {
+    background-color: #2563eb;
+    color: #fff;
+    position: relative;
+}
+
+.room-calendar-cell.today::after {
+    content: 'Heute';
+    position: absolute;
+    bottom: 6px;
+    right: 6px;
+    font-size: 0.65rem;
+    font-weight: 600;
+    text-transform: uppercase;
+}
+
+.update-output {
+    background: #0f172a;
+    color: #e2e8f0;
+    font-family: 'Fira Code', monospace;
+    font-size: 0.85rem;
+    border-radius: 0.5rem;
+    padding: 1rem;
+    max-height: 220px;
+    overflow-y: auto;
+}

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,714 @@
+<?php
+
+use ModPMS\Calendar;
+use ModPMS\Database;
+use ModPMS\RoomCategoryManager;
+use ModPMS\RoomManager;
+use ModPMS\SystemUpdater;
+
+require_once __DIR__ . '/../src/Database.php';
+require_once __DIR__ . '/../src/RoomCategoryManager.php';
+require_once __DIR__ . '/../src/Calendar.php';
+require_once __DIR__ . '/../src/RoomManager.php';
+require_once __DIR__ . '/../src/SystemUpdater.php';
+
+session_start();
+
+try {
+    $updateToken = bin2hex(random_bytes(32));
+} catch (Throwable $exception) {
+    $updateToken = bin2hex(hash('sha256', uniqid('', true), true));
+}
+
+$_SESSION['update_token'] = $updateToken;
+
+$alert = null;
+if (isset($_SESSION['alert'])) {
+    $alert = $_SESSION['alert'];
+    unset($_SESSION['alert']);
+}
+
+$categoryFormData = [
+    'id' => null,
+    'name' => '',
+    'description' => '',
+    'capacity' => 1,
+    'status' => 'aktiv',
+];
+
+$roomFormData = [
+    'id' => null,
+    'room_number' => '',
+    'category_id' => '',
+    'status' => 'frei',
+    'floor' => '',
+    'notes' => '',
+];
+
+$config = require __DIR__ . '/../config/app.php';
+$dbError = null;
+$categories = [];
+$rooms = [];
+$pdo = null;
+$categoryManager = null;
+$roomManager = null;
+
+try {
+    $pdo = Database::getConnection();
+    $categoryManager = new RoomCategoryManager($pdo);
+    $roomManager = new RoomManager($pdo);
+} catch (Throwable $exception) {
+    $dbError = $exception->getMessage();
+}
+
+$categoryStatuses = ['aktiv', 'inaktiv'];
+$roomStatuses = ['frei', 'belegt', 'wartung'];
+
+if ($pdo !== null && $_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['form'])) {
+    $form = $_POST['form'];
+
+    switch ($form) {
+        case 'category_create':
+        case 'category_update':
+            $name = trim($_POST['name'] ?? '');
+            $description = trim($_POST['description'] ?? '');
+            $capacityInput = trim((string) ($_POST['capacity'] ?? ''));
+            $capacityValue = (int) $capacityInput;
+            $status = $_POST['status'] ?? 'aktiv';
+            if (!in_array($status, $categoryStatuses, true)) {
+                $status = 'aktiv';
+            }
+
+            $categoryFormData = [
+                'id' => $form === 'category_update' ? (int) ($_POST['id'] ?? 0) : null,
+                'name' => $name,
+                'description' => $description,
+                'capacity' => $capacityInput !== '' ? $capacityInput : '',
+                'status' => $status,
+            ];
+
+            if ($name === '' || $capacityValue <= 0) {
+                $alert = [
+                    'type' => 'danger',
+                    'message' => 'Bitte geben Sie einen Namen und eine gültige Kapazität an.',
+                ];
+                break;
+            }
+
+            $payload = [
+                'name' => $name,
+                'description' => $description,
+                'capacity' => $capacityValue,
+                'status' => $status,
+            ];
+
+            if ($form === 'category_create') {
+                $categoryManager->add($payload);
+
+                $_SESSION['alert'] = [
+                    'type' => 'success',
+                    'message' => sprintf('Kategorie "%s" erfolgreich angelegt.', htmlspecialchars($name, ENT_QUOTES, 'UTF-8')),
+                ];
+
+                header('Location: index.php#category-management');
+                exit;
+            }
+
+            $categoryId = (int) ($_POST['id'] ?? 0);
+            if ($categoryId <= 0) {
+                $alert = [
+                    'type' => 'danger',
+                    'message' => 'Die Kategorie konnte nicht aktualisiert werden, da keine gültige ID übergeben wurde.',
+                ];
+                break;
+            }
+
+            if ($categoryManager->find($categoryId) === null) {
+                $alert = [
+                    'type' => 'danger',
+                    'message' => 'Die ausgewählte Kategorie wurde nicht gefunden.',
+                ];
+                break;
+            }
+
+            $categoryManager->update($categoryId, $payload);
+
+            $_SESSION['alert'] = [
+                'type' => 'success',
+                'message' => sprintf('Kategorie "%s" wurde aktualisiert.', htmlspecialchars($name, ENT_QUOTES, 'UTF-8')),
+            ];
+
+            header('Location: index.php#category-management');
+            exit;
+
+        case 'category_delete':
+            $categoryId = (int) ($_POST['id'] ?? 0);
+
+            if ($categoryId <= 0) {
+                $alert = [
+                    'type' => 'danger',
+                    'message' => 'Die Kategorie konnte nicht gelöscht werden, da keine gültige ID übergeben wurde.',
+                ];
+                break;
+            }
+
+            $category = $categoryManager->find($categoryId);
+            if ($category === null) {
+                $alert = [
+                    'type' => 'danger',
+                    'message' => 'Die ausgewählte Kategorie wurde nicht gefunden.',
+                ];
+                break;
+            }
+
+            $categoryManager->delete($categoryId);
+
+            $_SESSION['alert'] = [
+                'type' => 'success',
+                'message' => sprintf('Kategorie "%s" wurde gelöscht.', htmlspecialchars($category['name'], ENT_QUOTES, 'UTF-8')),
+            ];
+
+            header('Location: index.php#category-management');
+            exit;
+
+        case 'room_create':
+        case 'room_update':
+            $roomNumber = trim($_POST['room_number'] ?? '');
+            $roomStatus = $_POST['status'] ?? 'frei';
+            if (!in_array($roomStatus, $roomStatuses, true)) {
+                $roomStatus = 'frei';
+            }
+            $categoryIdInput = trim((string) ($_POST['category_id'] ?? ''));
+            $categoryId = $categoryIdInput === '' ? null : (int) $categoryIdInput;
+            $floor = trim($_POST['floor'] ?? '');
+            $notes = trim($_POST['notes'] ?? '');
+
+            $roomFormData = [
+                'id' => $form === 'room_update' ? (int) ($_POST['id'] ?? 0) : null,
+                'room_number' => $roomNumber,
+                'category_id' => $categoryIdInput,
+                'status' => $roomStatus,
+                'floor' => $floor,
+                'notes' => $notes,
+            ];
+
+            if ($roomNumber === '') {
+                $alert = [
+                    'type' => 'danger',
+                    'message' => 'Bitte geben Sie eine Zimmernummer an.',
+                ];
+                break;
+            }
+
+            $payload = [
+                'room_number' => $roomNumber,
+                'category_id' => $categoryId,
+                'status' => $roomStatus,
+                'floor' => $floor,
+                'notes' => $notes,
+            ];
+
+            if ($form === 'room_create') {
+                $roomManager->create($payload);
+
+                $_SESSION['alert'] = [
+                    'type' => 'success',
+                    'message' => sprintf('Zimmer "%s" erfolgreich angelegt.', htmlspecialchars($roomNumber, ENT_QUOTES, 'UTF-8')),
+                ];
+
+                header('Location: index.php#room-management');
+                exit;
+            }
+
+            $roomId = (int) ($_POST['id'] ?? 0);
+            if ($roomId <= 0) {
+                $alert = [
+                    'type' => 'danger',
+                    'message' => 'Das Zimmer konnte nicht aktualisiert werden, da keine gültige ID übergeben wurde.',
+                ];
+                break;
+            }
+
+            if ($roomManager->find($roomId) === null) {
+                $alert = [
+                    'type' => 'danger',
+                    'message' => 'Das ausgewählte Zimmer wurde nicht gefunden.',
+                ];
+                break;
+            }
+
+            $roomManager->update($roomId, $payload);
+
+            $_SESSION['alert'] = [
+                'type' => 'success',
+                'message' => sprintf('Zimmer "%s" wurde aktualisiert.', htmlspecialchars($roomNumber, ENT_QUOTES, 'UTF-8')),
+            ];
+
+            header('Location: index.php#room-management');
+            exit;
+
+        case 'room_delete':
+            $roomId = (int) ($_POST['id'] ?? 0);
+
+            if ($roomId <= 0) {
+                $alert = [
+                    'type' => 'danger',
+                    'message' => 'Das Zimmer konnte nicht gelöscht werden, da keine gültige ID übergeben wurde.',
+                ];
+                break;
+            }
+
+            $room = $roomManager->find($roomId);
+            if ($room === null) {
+                $alert = [
+                    'type' => 'danger',
+                    'message' => 'Das ausgewählte Zimmer wurde nicht gefunden.',
+                ];
+                break;
+            }
+
+            $roomManager->delete($roomId);
+
+            $_SESSION['alert'] = [
+                'type' => 'success',
+                'message' => sprintf('Zimmer "%s" wurde gelöscht.', htmlspecialchars($room['room_number'], ENT_QUOTES, 'UTF-8')),
+            ];
+
+            header('Location: index.php#room-management');
+            exit;
+    }
+} elseif ($pdo === null && $_SERVER['REQUEST_METHOD'] === 'POST') {
+    $alert = [
+        'type' => 'danger',
+        'message' => 'Aktionen sind ohne aktive Datenbankverbindung nicht verfügbar.',
+    ];
+}
+
+if ($pdo !== null) {
+    $categories = $categoryManager->all();
+    $rooms = $roomManager->all();
+}
+
+if ($pdo !== null && isset($_GET['editCategory']) && $categoryFormData['id'] === null) {
+    $categoryToEdit = $categoryManager->find((int) $_GET['editCategory']);
+
+    if ($categoryToEdit) {
+        $categoryFormData = [
+            'id' => (int) $categoryToEdit['id'],
+            'name' => $categoryToEdit['name'],
+            'description' => $categoryToEdit['description'] ?? '',
+            'capacity' => (int) $categoryToEdit['capacity'],
+            'status' => $categoryToEdit['status'],
+        ];
+    } elseif ($alert === null) {
+        $alert = [
+            'type' => 'warning',
+            'message' => 'Die ausgewählte Kategorie wurde nicht gefunden.',
+        ];
+    }
+}
+
+if ($pdo !== null && isset($_GET['editRoom']) && $roomFormData['id'] === null) {
+    $roomToEdit = $roomManager->find((int) $_GET['editRoom']);
+
+    if ($roomToEdit) {
+        $roomFormData = [
+            'id' => (int) $roomToEdit['id'],
+            'room_number' => $roomToEdit['room_number'],
+            'category_id' => $roomToEdit['category_id'] !== null ? (string) $roomToEdit['category_id'] : '',
+            'status' => $roomToEdit['status'],
+            'floor' => $roomToEdit['floor'] ?? '',
+            'notes' => $roomToEdit['notes'] ?? '',
+        ];
+    } elseif ($alert === null) {
+        $alert = [
+            'type' => 'warning',
+            'message' => 'Das ausgewählte Zimmer wurde nicht gefunden.',
+        ];
+    }
+}
+
+$calendar = new Calendar();
+$days = $calendar->daysOfMonth();
+
+$updater = new SystemUpdater(dirname(__DIR__), $config['repository']['branch'], $config['repository']['url']);
+
+?>
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title><?= htmlspecialchars($config['name']) ?> · Basis Modul</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link rel="stylesheet" href="assets/css/style.css">
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-light bg-white shadow-sm">
+      <div class="container">
+        <a class="navbar-brand" href="#">🏨 <?= htmlspecialchars($config['name']) ?></a>
+        <div class="d-flex align-items-center gap-3">
+          <span class="badge rounded-pill text-bg-primary">Version <?= htmlspecialchars($config['version']) ?></span>
+        </div>
+      </div>
+    </nav>
+
+    <main class="container py-5">
+      <?php if ($dbError): ?>
+        <div class="alert alert-danger" role="alert">
+          <?= htmlspecialchars($dbError) ?><br>
+          <small>Bitte führen Sie die <a href="install.php">Installation</a> durch oder prüfen Sie die Verbindungseinstellungen.</small>
+        </div>
+      <?php endif; ?>
+
+      <?php if ($alert): ?>
+        <div class="alert alert-<?= htmlspecialchars($alert['type']) ?> alert-dismissible fade show" role="alert">
+          <?= $alert['message'] ?>
+          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+      <?php endif; ?>
+
+      <div class="row g-4">
+        <div class="col-lg-8">
+          <div class="card module-card h-100">
+            <div class="card-header bg-transparent border-0 d-flex justify-content-between align-items-center">
+              <div>
+                <h2 class="h5 mb-1">Dashboard</h2>
+                <p class="text-muted mb-0">Kalender und aktuelle Auslastung im Blick.</p>
+              </div>
+              <span class="badge text-bg-info">Basis-Modul</span>
+            </div>
+            <div class="card-body">
+              <div class="d-flex justify-content-between align-items-center mb-3">
+                <h3 class="h4 mb-0"><?= htmlspecialchars($calendar->monthLabel()) ?></h3>
+                <span class="text-muted">Heute: <?= (new DateTime())->format('d.m.Y') ?></span>
+              </div>
+              <div class="calendar-grid-wrapper">
+                <table class="table table-bordered align-middle room-calendar">
+                  <thead class="table-light">
+                    <tr>
+                      <th scope="col" class="room-column">Zimmer</th>
+                      <?php foreach ($days as $day): ?>
+                        <th scope="col" class="text-center">
+                          <div class="day-number"><?= $day['day'] ?></div>
+                          <small class="text-muted text-uppercase"><?= $day['weekday'] ?></small>
+                        </th>
+                      <?php endforeach; ?>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <?php foreach ($rooms as $room): ?>
+                      <tr>
+                        <th scope="row" class="room-label">
+                          <div class="fw-semibold">Zimmer <?= htmlspecialchars($room['number']) ?></div>
+                          <small class="text-muted">Status: <?= htmlspecialchars(ucfirst($room['status'])) ?></small>
+                        </th>
+                        <?php foreach ($days as $day): ?>
+                          <td class="room-calendar-cell <?= $day['isToday'] ? 'today' : '' ?>" data-date="<?= $day['date'] ?>" data-room="<?= htmlspecialchars($room['number']) ?>">
+                            <span class="visually-hidden">Zimmer <?= htmlspecialchars($room['number']) ?> am <?= $day['date'] ?></span>
+                          </td>
+                        <?php endforeach; ?>
+                      </tr>
+                    <?php endforeach; ?>
+                    <?php if (empty($rooms)): ?>
+                      <tr>
+                        <td colspan="<?= count($days) + 1 ?>" class="text-muted text-center py-4">Noch keine Zimmer angelegt.</td>
+                      </tr>
+                    <?php endif; ?>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-lg-4">
+          <div class="card module-card h-100">
+            <div class="card-header bg-transparent border-0">
+              <h2 class="h5 mb-1">Schnellstatistik</h2>
+              <p class="text-muted mb-0">Überblick über Zimmerkategorien.</p>
+            </div>
+            <div class="card-body">
+              <ul class="list-group list-group-flush">
+                <?php foreach ($categories as $category): ?>
+                  <li class="list-group-item d-flex justify-content-between align-items-start">
+                    <div>
+                      <div class="fw-semibold"><?= htmlspecialchars($category['name']) ?></div>
+                      <small class="text-muted">Kapazität: <?= (int) $category['capacity'] ?> Gäste</small>
+                    </div>
+                    <span class="badge <?= $category['status'] === 'aktiv' ? 'text-bg-success' : 'text-bg-secondary' ?>">
+                      <?= htmlspecialchars(ucfirst($category['status'])) ?>
+                    </span>
+                  </li>
+                <?php endforeach; ?>
+                <?php if (empty($categories)): ?>
+                  <li class="list-group-item text-muted">Noch keine Kategorien erfasst.</li>
+                <?php endif; ?>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="row g-4 mt-1">
+        <div class="col-lg-8">
+          <div class="card module-card h-100" id="category-management">
+            <?php $isEditingCategory = $categoryFormData['id'] !== null; ?>
+            <div class="card-header bg-transparent border-0 d-flex justify-content-between align-items-start flex-wrap gap-2">
+              <div>
+                <h2 class="h5 mb-1">Zimmerkategorien verwalten</h2>
+                <p class="text-muted mb-0"><?= $isEditingCategory ? 'Bestehende Kategorie bearbeiten oder aktualisieren.' : 'Neue Kategorien für die Belegung anlegen.' ?></p>
+              </div>
+              <?php if ($isEditingCategory): ?>
+                <span class="badge text-bg-primary">Bearbeitung</span>
+              <?php endif; ?>
+            </div>
+            <div class="card-body">
+              <form method="post" class="row g-3" id="category-form">
+                <input type="hidden" name="form" value="<?= $isEditingCategory ? 'category_update' : 'category_create' ?>">
+                <?php if ($isEditingCategory): ?>
+                  <input type="hidden" name="id" value="<?= (int) $categoryFormData['id'] ?>">
+                <?php endif; ?>
+                <div class="col-12">
+                  <label for="category-name" class="form-label">Bezeichnung *</label>
+                  <input type="text" class="form-control" id="category-name" name="name" value="<?= htmlspecialchars((string) $categoryFormData['name']) ?>" required <?= $pdo === null ? 'disabled' : '' ?>>
+                </div>
+                <div class="col-12">
+                  <label for="category-description" class="form-label">Beschreibung</label>
+                  <textarea class="form-control" id="category-description" name="description" rows="2" <?= $pdo === null ? 'disabled' : '' ?>><?= htmlspecialchars((string) $categoryFormData['description']) ?></textarea>
+                </div>
+                <div class="col-md-6">
+                  <label for="category-capacity" class="form-label">Kapazität *</label>
+                  <input type="number" min="1" class="form-control" id="category-capacity" name="capacity" value="<?= htmlspecialchars((string) $categoryFormData['capacity']) ?>" required <?= $pdo === null ? 'disabled' : '' ?>>
+                </div>
+                <div class="col-md-6">
+                  <label for="category-status" class="form-label">Status</label>
+                  <select class="form-select" id="category-status" name="status" <?= $pdo === null ? 'disabled' : '' ?>>
+                    <?php foreach ($categoryStatuses as $status): ?>
+                      <option value="<?= htmlspecialchars($status) ?>" <?= $categoryFormData['status'] === $status ? 'selected' : '' ?>><?= htmlspecialchars(ucfirst($status)) ?></option>
+                    <?php endforeach; ?>
+                  </select>
+                </div>
+                <div class="col-12 d-flex justify-content-end align-items-center flex-wrap gap-2">
+                  <?php if ($isEditingCategory): ?>
+                    <a href="index.php#category-management" class="btn btn-outline-secondary">Abbrechen</a>
+                  <?php endif; ?>
+                  <button type="submit" class="btn btn-primary" <?= $pdo === null ? 'disabled' : '' ?>><?= $isEditingCategory ? 'Kategorie aktualisieren' : 'Kategorie speichern' ?></button>
+                </div>
+              </form>
+              <?php if ($pdo === null): ?>
+                <p class="text-muted mt-3 mb-0">Die Formularfelder sind deaktiviert, bis eine gültige Datenbankverbindung besteht.</p>
+              <?php endif; ?>
+
+              <?php if ($pdo !== null): ?>
+                <div class="table-responsive mt-4">
+                  <table class="table table-sm align-middle mb-0">
+                    <thead class="table-light">
+                      <tr>
+                        <th scope="col">Bezeichnung</th>
+                        <th scope="col">Kapazität</th>
+                        <th scope="col">Status</th>
+                        <th scope="col" class="text-end">Aktionen</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <?php foreach ($categories as $category): ?>
+                        <tr>
+                          <td>
+                            <div class="fw-semibold"><?= htmlspecialchars($category['name']) ?></div>
+                            <?php if (!empty($category['description'])): ?>
+                              <div class="small text-muted"><?= htmlspecialchars($category['description']) ?></div>
+                            <?php endif; ?>
+                          </td>
+                          <td><?= (int) $category['capacity'] ?> Gäste</td>
+                          <td>
+                            <span class="badge <?= $category['status'] === 'aktiv' ? 'text-bg-success' : 'text-bg-secondary' ?>"><?= htmlspecialchars(ucfirst($category['status'])) ?></span>
+                          </td>
+                          <td class="text-end">
+                            <div class="d-flex justify-content-end gap-2">
+                              <a class="btn btn-outline-secondary btn-sm" href="index.php?editCategory=<?= (int) $category['id'] ?>#category-management">Bearbeiten</a>
+                              <form method="post" onsubmit="return confirm('Kategorie wirklich löschen?');">
+                                <input type="hidden" name="form" value="category_delete">
+                                <input type="hidden" name="id" value="<?= (int) $category['id'] ?>">
+                                <button type="submit" class="btn btn-outline-danger btn-sm">Löschen</button>
+                              </form>
+                            </div>
+                          </td>
+                        </tr>
+                      <?php endforeach; ?>
+                      <?php if (empty($categories)): ?>
+                        <tr>
+                          <td colspan="4" class="text-center text-muted py-3">Noch keine Kategorien erfasst.</td>
+                        </tr>
+                      <?php endif; ?>
+                    </tbody>
+                  </table>
+                </div>
+              <?php endif; ?>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-4">
+          <div class="card module-card h-100">
+            <div class="card-header bg-transparent border-0 d-flex justify-content-between align-items-center">
+              <div>
+                <h2 class="h5 mb-1">Systemupdates</h2>
+                <p class="text-muted mb-0">Version prüfen und GitHub Updates abrufen.</p>
+              </div>
+              <span class="badge text-bg-warning">Dev Tools</span>
+            </div>
+            <div class="card-body">
+              <form method="post" action="update.php" class="d-flex flex-column gap-3">
+                <input type="hidden" name="token" value="<?= htmlspecialchars($updateToken, ENT_QUOTES, 'UTF-8') ?>">
+                <div>
+                  <label class="form-label">Repository</label>
+                  <p class="form-control-plaintext mb-0">
+                    <?php $repositoryLabel = rtrim(str_replace(['https://', 'http://'], '', $config['repository']['url']), '/'); ?>
+                    <a href="<?= htmlspecialchars($config['repository']['url']) ?>" target="_blank" rel="noopener">
+                      <?= htmlspecialchars($repositoryLabel) ?>
+                    </a>
+                  </p>
+                </div>
+                <div>
+                  <label for="branch" class="form-label">Branch</label>
+                  <input type="text" class="form-control" id="branch" name="branch" value="<?= htmlspecialchars($config['repository']['branch']) ?>">
+                </div>
+                <div class="d-flex justify-content-between align-items-center">
+                  <div>
+                    <span class="text-muted d-block">Aktuelle Version</span>
+                    <span class="fs-5 fw-semibold"><?= htmlspecialchars($config['version']) ?></span>
+                  </div>
+                  <button type="submit" class="btn btn-outline-primary">Update ausführen</button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="row g-4 mt-1">
+        <div class="col-12">
+          <div class="card module-card" id="room-management">
+            <?php $isEditingRoom = $roomFormData['id'] !== null; ?>
+            <div class="card-header bg-transparent border-0 d-flex justify-content-between align-items-start flex-wrap gap-2">
+              <div>
+                <h2 class="h5 mb-1">Zimmerstamm verwalten</h2>
+                <p class="text-muted mb-0"><?= $isEditingRoom ? 'Zimmerdaten bearbeiten und Änderungen speichern.' : 'Neue Zimmer erfassen und bestehenden Bestand pflegen.' ?></p>
+              </div>
+              <?php if ($isEditingRoom): ?>
+                <span class="badge text-bg-primary">Bearbeitung</span>
+              <?php endif; ?>
+            </div>
+            <div class="card-body">
+              <form method="post" class="row g-3" id="room-form">
+                <input type="hidden" name="form" value="<?= $isEditingRoom ? 'room_update' : 'room_create' ?>">
+                <?php if ($isEditingRoom): ?>
+                  <input type="hidden" name="id" value="<?= (int) $roomFormData['id'] ?>">
+                <?php endif; ?>
+                <div class="col-md-3">
+                  <label for="room-number" class="form-label">Zimmernummer *</label>
+                  <input type="text" class="form-control" id="room-number" name="room_number" value="<?= htmlspecialchars((string) $roomFormData['room_number']) ?>" required <?= $pdo === null ? 'disabled' : '' ?>>
+                </div>
+                <div class="col-md-3">
+                  <label for="room-category" class="form-label">Kategorie</label>
+                  <select class="form-select" id="room-category" name="category_id" <?= $pdo === null ? 'disabled' : '' ?>>
+                    <option value="">Keine Zuordnung</option>
+                    <?php foreach ($categories as $category): ?>
+                      <option value="<?= (int) $category['id'] ?>" <?= $roomFormData['category_id'] !== '' && (int) $roomFormData['category_id'] === (int) $category['id'] ? 'selected' : '' ?>><?= htmlspecialchars($category['name']) ?></option>
+                    <?php endforeach; ?>
+                  </select>
+                </div>
+                <div class="col-md-3">
+                  <label for="room-status" class="form-label">Status</label>
+                  <select class="form-select" id="room-status" name="status" <?= $pdo === null ? 'disabled' : '' ?>>
+                    <?php foreach ($roomStatuses as $status): ?>
+                      <option value="<?= htmlspecialchars($status) ?>" <?= $roomFormData['status'] === $status ? 'selected' : '' ?>><?= htmlspecialchars(ucfirst($status)) ?></option>
+                    <?php endforeach; ?>
+                  </select>
+                </div>
+                <div class="col-md-3">
+                  <label for="room-floor" class="form-label">Etage</label>
+                  <input type="text" class="form-control" id="room-floor" name="floor" value="<?= htmlspecialchars((string) $roomFormData['floor']) ?>" <?= $pdo === null ? 'disabled' : '' ?>>
+                </div>
+                <div class="col-12">
+                  <label for="room-notes" class="form-label">Notizen</label>
+                  <textarea class="form-control" id="room-notes" name="notes" rows="2" <?= $pdo === null ? 'disabled' : '' ?>><?= htmlspecialchars((string) $roomFormData['notes']) ?></textarea>
+                </div>
+                <div class="col-12 d-flex justify-content-end align-items-center flex-wrap gap-2">
+                  <?php if ($isEditingRoom): ?>
+                    <a href="index.php#room-management" class="btn btn-outline-secondary">Abbrechen</a>
+                  <?php endif; ?>
+                  <button type="submit" class="btn btn-primary" <?= $pdo === null ? 'disabled' : '' ?>><?= $isEditingRoom ? 'Zimmer aktualisieren' : 'Zimmer speichern' ?></button>
+                </div>
+              </form>
+              <?php if ($pdo === null): ?>
+                <p class="text-muted mt-3 mb-0">Die Formularfelder sind deaktiviert, bis eine gültige Datenbankverbindung besteht.</p>
+              <?php endif; ?>
+
+              <?php if ($pdo !== null): ?>
+                <div class="table-responsive mt-4">
+                  <table class="table table-sm align-middle mb-0">
+                    <thead class="table-light">
+                      <tr>
+                        <th scope="col">Zimmer</th>
+                        <th scope="col">Kategorie</th>
+                        <th scope="col">Status</th>
+                        <th scope="col">Etage</th>
+                        <th scope="col">Notizen</th>
+                        <th scope="col" class="text-end">Aktionen</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <?php foreach ($rooms as $room): ?>
+                        <?php
+                          $roomStatusClass = 'text-bg-light border';
+                          if ($room['status'] === 'frei') {
+                              $roomStatusClass = 'text-bg-success';
+                          } elseif ($room['status'] === 'belegt') {
+                              $roomStatusClass = 'text-bg-danger';
+                          } elseif ($room['status'] === 'wartung') {
+                              $roomStatusClass = 'text-bg-warning';
+                          }
+                        ?>
+                        <tr>
+                          <td class="fw-semibold"><?= htmlspecialchars($room['number']) ?></td>
+                          <td>
+                            <?php if ($room['category_name']): ?>
+                              <?= htmlspecialchars($room['category_name']) ?>
+                            <?php else: ?>
+                              <span class="text-muted">Keine</span>
+                            <?php endif; ?>
+                          </td>
+                          <td><span class="badge <?= $roomStatusClass ?>"><?= htmlspecialchars(ucfirst($room['status'])) ?></span></td>
+                          <td><?= $room['floor'] !== null ? htmlspecialchars($room['floor']) : '—' ?></td>
+                          <td><?= $room['notes'] !== null && $room['notes'] !== '' ? htmlspecialchars($room['notes']) : '—' ?></td>
+                          <td class="text-end">
+                            <div class="d-flex justify-content-end gap-2">
+                              <a class="btn btn-outline-secondary btn-sm" href="index.php?editRoom=<?= (int) $room['id'] ?>#room-management">Bearbeiten</a>
+                              <form method="post" onsubmit="return confirm('Zimmer wirklich löschen?');">
+                                <input type="hidden" name="form" value="room_delete">
+                                <input type="hidden" name="id" value="<?= (int) $room['id'] ?>">
+                                <button type="submit" class="btn btn-outline-danger btn-sm">Löschen</button>
+                              </form>
+                            </div>
+                          </td>
+                        </tr>
+                      <?php endforeach; ?>
+                      <?php if (empty($rooms)): ?>
+                        <tr>
+                          <td colspan="6" class="text-center text-muted py-3">Noch keine Zimmer angelegt.</td>
+                        </tr>
+                      <?php endif; ?>
+                    </tbody>
+                  </table>
+                </div>
+              <?php endif; ?>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+  </body>
+</html>

--- a/public/install.php
+++ b/public/install.php
@@ -1,0 +1,356 @@
+<?php
+
+session_start();
+
+$config = require __DIR__ . '/../config/app.php';
+$databaseConfigPath = __DIR__ . '/../config/database.php';
+$existingDatabaseConfig = is_readable($databaseConfigPath) ? include $databaseConfigPath : null;
+if ($existingDatabaseConfig !== null && !is_array($existingDatabaseConfig)) {
+    $existingDatabaseConfig = null;
+}
+$configDirectory = dirname($databaseConfigPath);
+
+$step = isset($_GET['step']) ? max(1, min(3, (int) $_GET['step'])) : 1;
+$errors = [];
+$successData = $_SESSION['install_success'] ?? null;
+if ($successData) {
+    unset($_SESSION['install_success']);
+}
+
+$requirements = [
+    'phpVersion' => version_compare(PHP_VERSION, '8.1.0', '>='),
+    'pdoExtension' => extension_loaded('pdo_mysql'),
+    'configWritable' => $existingDatabaseConfig ? is_writable($databaseConfigPath) : is_writable($configDirectory),
+    'configExists' => (bool) $existingDatabaseConfig,
+];
+
+$configWritableLabel = $requirements['configExists']
+    ? 'Schreibrechte für <code>config/database.php</code>'
+    : 'Schreibrechte für <code>config/</code>';
+$configWritableDescription = $requirements['configExists']
+    ? 'Erforderlich, um die bestehende Konfiguration zu aktualisieren.'
+    : 'Erforderlich, um <code>database.php</code> anzulegen.';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $currentStep = (int) ($_POST['step'] ?? 1);
+
+    if ($currentStep === 1 && $requirements['phpVersion'] && $requirements['pdoExtension'] && $requirements['configWritable']) {
+        header('Location: install.php?step=2');
+        exit;
+    }
+
+    if ($currentStep === 2) {
+        $dbHost = trim($_POST['db_host'] ?? '');
+        $dbPort = trim($_POST['db_port'] ?? '3306');
+        $dbName = trim($_POST['db_name'] ?? '');
+        $dbUser = trim($_POST['db_user'] ?? '');
+        $dbPassword = $_POST['db_password'] ?? '';
+        $createDatabase = isset($_POST['create_database']);
+
+        if ($dbHost === '' || $dbName === '' || $dbUser === '') {
+            $errors[] = 'Bitte füllen Sie alle Pflichtfelder aus.';
+        }
+
+        if ($dbName !== '' && !preg_match('/^[A-Za-z0-9_]+$/', $dbName)) {
+            $errors[] = 'Der Datenbankname darf nur Buchstaben, Zahlen und Unterstriche enthalten.';
+        }
+
+        if ($dbPort !== '' && !preg_match('/^[0-9]+$/', $dbPort)) {
+            $errors[] = 'Der Port darf nur Ziffern enthalten.';
+        }
+
+        if (!$errors) {
+            try {
+                $dsn = sprintf('mysql:host=%s;port=%s;charset=utf8mb4', $dbHost, $dbPort !== '' ? $dbPort : '3306');
+                $pdo = new PDO($dsn, $dbUser, $dbPassword, [
+                    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+                ]);
+
+                if ($createDatabase) {
+                    $pdo->exec(sprintf('CREATE DATABASE IF NOT EXISTS `%s` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci', str_replace('`', '', $dbName)));
+                }
+
+                $pdo->exec(sprintf('USE `%s`', str_replace('`', '', $dbName)));
+
+                $pdo->exec('CREATE TABLE IF NOT EXISTS room_categories (
+                    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                    name VARCHAR(150) NOT NULL,
+                    description TEXT NULL,
+                    capacity INT UNSIGNED NOT NULL DEFAULT 1,
+                    status ENUM("aktiv", "inaktiv") NOT NULL DEFAULT "aktiv",
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci');
+
+                $pdo->exec('CREATE TABLE IF NOT EXISTS rooms (
+                    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+                    room_number VARCHAR(20) NOT NULL,
+                    category_id INT UNSIGNED NULL,
+                    status ENUM("frei", "belegt", "wartung") NOT NULL DEFAULT "frei",
+                    floor VARCHAR(50) NULL,
+                    notes TEXT NULL,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                    CONSTRAINT fk_rooms_category FOREIGN KEY (category_id) REFERENCES room_categories(id) ON DELETE SET NULL
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci');
+
+                $seedCategory = $pdo->query('SELECT COUNT(*) AS total FROM room_categories')->fetchColumn();
+                if ((int) $seedCategory === 0) {
+                    $stmt = $pdo->prepare('INSERT INTO room_categories (name, description, capacity, status) VALUES (?, ?, ?, ?)');
+                    $stmt->execute(['Standardzimmer', 'Komfortable Zimmer mit Queen-Size-Bett', 2, 'aktiv']);
+                    $stmt->execute(['Deluxe Suite', 'Großzügige Suite mit Wohnbereich', 4, 'aktiv']);
+                }
+
+                $seedRooms = $pdo->query('SELECT COUNT(*) AS total FROM rooms')->fetchColumn();
+                if ((int) $seedRooms === 0) {
+                    $stmt = $pdo->prepare('INSERT INTO rooms (room_number, category_id, status, floor) VALUES (?, ?, ?, ?)');
+                    $stmt->execute(['101', 1, 'frei', '1']);
+                    $stmt->execute(['102', 1, 'belegt', '1']);
+                    $stmt->execute(['201', 2, 'frei', '2']);
+                }
+
+                $databaseConfig = [
+                    'driver' => 'mysql',
+                    'host' => $dbHost,
+                    'port' => $dbPort,
+                    'database' => $dbName,
+                    'username' => $dbUser,
+                    'password' => $dbPassword,
+                    'charset' => 'utf8mb4',
+                    'collation' => 'utf8mb4_unicode_ci',
+                ];
+
+                $configContent = "<?php\n\nreturn " . var_export($databaseConfig, true) . ";\n";
+
+                if (false === file_put_contents($databaseConfigPath, $configContent)) {
+                    throw new RuntimeException('Die Konfigurationsdatei konnte nicht geschrieben werden.');
+                }
+
+                $_SESSION['install_success'] = [
+                    'database' => $dbName,
+                    'host' => $dbHost,
+                    'port' => $dbPort,
+                ];
+
+                header('Location: install.php?step=3');
+                exit;
+            } catch (Throwable $exception) {
+                $errors[] = $exception->getMessage();
+            }
+        }
+
+        $step = 2;
+    }
+}
+
+if ($step === 3 && !$successData) {
+    $step = 1;
+}
+
+?>
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Installation · <?= htmlspecialchars($config['name']) ?></title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <style>
+      body {
+        min-height: 100vh;
+        background: linear-gradient(135deg, #f8fafc 0%, #eef2ff 100%);
+      }
+      .install-card {
+        border: none;
+        border-radius: 1rem;
+        box-shadow: 0 20px 45px rgba(15, 23, 42, 0.15);
+      }
+      .step-badge {
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: 600;
+      }
+      .requirement-item {
+        border-radius: 0.75rem;
+        border: 1px solid rgba(15, 23, 42, 0.08);
+        padding: 1rem;
+        background: #fff;
+      }
+    </style>
+  </head>
+  <body class="d-flex align-items-center py-5">
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-lg-8 col-xl-7">
+          <div class="card install-card">
+            <div class="card-body p-5">
+              <div class="d-flex justify-content-between align-items-center mb-4">
+                <div>
+                  <h1 class="h3 mb-1">Installation · <?= htmlspecialchars($config['name']) ?></h1>
+                  <p class="text-muted mb-0">Grafischer Assistent zur Einrichtung der Datenbank.</p>
+                </div>
+                <span class="badge text-bg-primary">Version <?= htmlspecialchars($config['version']) ?></span>
+              </div>
+
+              <?php if ($errors): ?>
+                <div class="alert alert-danger">
+                  <h2 class="h6 mb-2">Es sind Fehler aufgetreten:</h2>
+                  <ul class="mb-0">
+                    <?php foreach ($errors as $error): ?>
+                      <li><?= htmlspecialchars($error) ?></li>
+                    <?php endforeach; ?>
+                  </ul>
+                </div>
+              <?php endif; ?>
+
+              <?php if ($step === 1): ?>
+                <form method="post" class="d-flex flex-column gap-4">
+                  <input type="hidden" name="step" value="1">
+                  <div class="d-flex align-items-center gap-3">
+                    <div class="step-badge bg-primary text-white">1</div>
+                    <div>
+                      <h2 class="h5 mb-1">Systemprüfung</h2>
+                      <p class="text-muted mb-0">Wir prüfen, ob Ihr Server die Mindestanforderungen erfüllt.</p>
+                    </div>
+                  </div>
+
+                  <div class="d-grid gap-3">
+                    <div class="requirement-item d-flex justify-content-between align-items-center">
+                      <div>
+                        <strong>PHP-Version ≥ 8.1</strong>
+                        <p class="text-muted mb-0">Aktuelle Version: <?= PHP_VERSION ?></p>
+                      </div>
+                      <span class="badge <?= $requirements['phpVersion'] ? 'text-bg-success' : 'text-bg-danger' ?>">
+                        <?= $requirements['phpVersion'] ? 'OK' : 'Nicht erfüllt' ?>
+                      </span>
+                    </div>
+                    <div class="requirement-item d-flex justify-content-between align-items-center">
+                      <div>
+                        <strong>PDO MySQL Erweiterung</strong>
+                        <p class="text-muted mb-0">Benötigt für die Datenbankverbindung.</p>
+                      </div>
+                      <span class="badge <?= $requirements['pdoExtension'] ? 'text-bg-success' : 'text-bg-danger' ?>">
+                        <?= $requirements['pdoExtension'] ? 'Aktiv' : 'Fehlt' ?>
+                      </span>
+                    </div>
+                    <div class="requirement-item d-flex justify-content-between align-items-center">
+                      <div>
+                        <strong><?= $configWritableLabel ?></strong>
+                        <p class="text-muted mb-0"><?= $configWritableDescription ?></p>
+                      </div>
+                      <span class="badge <?= $requirements['configWritable'] ? 'text-bg-success' : 'text-bg-danger' ?>">
+                        <?= $requirements['configWritable'] ? 'Beschreibbar' : 'Keine Rechte' ?>
+                      </span>
+                    </div>
+                  </div>
+
+                  <?php if ($requirements['configExists']): ?>
+                    <div class="alert alert-warning mb-0">
+                      <strong>Hinweis:</strong> Eine bestehende <code>config/database.php</code> wurde gefunden. Bei der erneuten Installation wird diese Datei überschrieben.
+                    </div>
+                  <?php endif; ?>
+
+                  <div class="d-flex justify-content-end">
+                    <button type="submit" class="btn btn-primary" <?= ($requirements['phpVersion'] && $requirements['pdoExtension'] && $requirements['configWritable']) ? '' : 'disabled' ?>>Weiter zu Schritt 2</button>
+                  </div>
+                </form>
+              <?php elseif ($step === 2): ?>
+                <?php
+                  $prefill = [
+                      'host' => $_POST['db_host'] ?? ($existingDatabaseConfig['host'] ?? 'localhost'),
+                      'port' => $_POST['db_port'] ?? ($existingDatabaseConfig['port'] ?? '3306'),
+                      'name' => $_POST['db_name'] ?? ($existingDatabaseConfig['database'] ?? $config['name']),
+                      'user' => $_POST['db_user'] ?? ($existingDatabaseConfig['username'] ?? ''),
+                  ];
+                ?>
+                <form method="post" class="d-flex flex-column gap-4">
+                  <input type="hidden" name="step" value="2">
+
+                  <div class="d-flex align-items-center gap-3">
+                    <div class="step-badge bg-primary text-white">2</div>
+                    <div>
+                      <h2 class="h5 mb-1">Datenbank konfigurieren</h2>
+                      <p class="text-muted mb-0">Bitte geben Sie Ihre MySQL-Zugangsdaten ein.</p>
+                    </div>
+                  </div>
+
+                  <?php if ($requirements['configExists']): ?>
+                    <div class="alert alert-info mb-0">
+                      Die bestehenden Verbindungsdaten wurden vorausgefüllt. Änderungen werden in <code>config/database.php</code> gespeichert.
+                    </div>
+                  <?php endif; ?>
+
+                  <div class="row g-3">
+                    <div class="col-md-6">
+                      <label for="db_host" class="form-label">Host *</label>
+                      <input type="text" class="form-control" id="db_host" name="db_host" value="<?= htmlspecialchars($prefill['host']) ?>" required>
+                    </div>
+                    <div class="col-md-6">
+                      <label for="db_port" class="form-label">Port</label>
+                      <input type="text" class="form-control" id="db_port" name="db_port" value="<?= htmlspecialchars($prefill['port']) ?>">
+                    </div>
+                    <div class="col-md-6">
+                      <label for="db_name" class="form-label">Datenbankname *</label>
+                      <input type="text" class="form-control" id="db_name" name="db_name" value="<?= htmlspecialchars($prefill['name']) ?>" required>
+                    </div>
+                    <div class="col-md-6">
+                      <label for="db_user" class="form-label">Benutzer *</label>
+                      <input type="text" class="form-control" id="db_user" name="db_user" value="<?= htmlspecialchars($prefill['user']) ?>" required>
+                    </div>
+                    <div class="col-12">
+                      <label for="db_password" class="form-label">Passwort</label>
+                      <input type="password" class="form-control" id="db_password" name="db_password" value="<?= htmlspecialchars($_POST['db_password'] ?? '') ?>">
+                    </div>
+                    <div class="col-12">
+                      <div class="form-check">
+                        <input class="form-check-input" type="checkbox" value="1" id="create_database" name="create_database" <?= isset($_POST['create_database']) ? 'checked' : '' ?>>
+                        <label class="form-check-label" for="create_database">
+                          Datenbank automatisch anlegen (falls nicht vorhanden)
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="d-flex justify-content-between">
+                    <a class="btn btn-link" href="install.php?step=1">Zurück</a>
+                    <button type="submit" class="btn btn-primary">Installation starten</button>
+                  </div>
+                </form>
+              <?php elseif ($step === 3 && $successData): ?>
+                <div class="d-flex align-items-center gap-3 mb-4">
+                  <div class="step-badge bg-success text-white">3</div>
+                  <div>
+                    <h2 class="h5 mb-1">Installation abgeschlossen</h2>
+                    <p class="text-muted mb-0">Ihre Datenbank wurde erfolgreich eingerichtet.</p>
+                  </div>
+                </div>
+
+                <div class="alert alert-success">
+                  <h2 class="h6 mb-2">Verbindung hergestellt</h2>
+                  <p class="mb-0">Die Datenbank <strong><?= htmlspecialchars($successData['database']) ?></strong> auf <strong><?= htmlspecialchars($successData['host']) ?><?= $successData['port'] ? ':' . htmlspecialchars($successData['port']) : '' ?></strong> wurde konfiguriert. Sie können sich jetzt im Dashboard anmelden.</p>
+                </div>
+
+                <div class="card border-0 shadow-sm">
+                  <div class="card-body">
+                    <h3 class="h6 text-uppercase text-muted mb-3">Nächste Schritte</h3>
+                    <ul class="mb-4">
+                      <li>Überprüfen Sie die generierte Datei <code>config/database.php</code> und passen Sie sie bei Bedarf an.</li>
+                      <li>Entfernen oder sichern Sie <code>public/install.php</code>, um unbefugte Zugriffe zu verhindern.</li>
+                      <li>Melden Sie sich am <a href="index.php">Dashboard</a> an und beginnen Sie mit der Konfiguration.</li>
+                    </ul>
+                    <a href="index.php" class="btn btn-success">Zum Dashboard</a>
+                  </div>
+                </div>
+              <?php endif; ?>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/public/update.php
+++ b/public/update.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use ModPMS\SystemUpdater;
+
+require_once __DIR__ . '/../src/SystemUpdater.php';
+
+session_start();
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo 'Methode nicht erlaubt';
+    exit;
+}
+
+if (!isset($_POST['token'], $_SESSION['update_token']) || !hash_equals($_SESSION['update_token'], $_POST['token'])) {
+    http_response_code(400);
+    echo 'Ungültiger Token';
+    exit;
+}
+
+unset($_SESSION['update_token']);
+
+$config = require __DIR__ . '/../config/app.php';
+$branch = $config['repository']['branch'];
+
+if (isset($_POST['branch']) && is_string($_POST['branch'])) {
+    $candidate = trim($_POST['branch']);
+    if ($candidate !== '') {
+        $branch = $candidate;
+    }
+}
+
+$updater = new SystemUpdater(dirname(__DIR__), $branch, $config['repository']['url']);
+
+$result = $updater->performUpdate();
+
+$log = [$result['message']];
+if (isset($result['details'])) {
+    foreach ($result['details'] as $detail) {
+        $log[] = sprintf('> %s (Status: %d)', $detail['command'], $detail['status']);
+        foreach ($detail['output'] as $line) {
+            $log[] = '  ' . $line;
+        }
+    }
+}
+
+$_SESSION['update_output'] = $log;
+$_SESSION['alert'] = [
+    'type' => $result['success'] ? 'success' : 'danger',
+    'message' => $result['message'],
+];
+
+header('Location: index.php');
+exit;

--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace ModPMS;
+
+use DateTimeImmutable;
+use IntlDateFormatter;
+
+class Calendar
+{
+    private DateTimeImmutable $currentDate;
+
+    public function __construct(?DateTimeImmutable $date = null)
+    {
+        $this->currentDate = $date ?? new DateTimeImmutable('first day of this month');
+    }
+
+    public function monthLabel(): string
+    {
+        $formatter = new IntlDateFormatter(
+            'de_DE',
+            IntlDateFormatter::LONG,
+            IntlDateFormatter::NONE,
+            $this->currentDate->getTimezone()->getName(),
+            IntlDateFormatter::GREGORIAN,
+            'LLLL yyyy'
+        );
+
+        return $formatter->format($this->currentDate) ?: $this->currentDate->format('F Y');
+    }
+
+    /**
+     * @return array<int, array<int, array<string, int|string|bool>>>
+     */
+    public function weeks(): array
+    {
+        $start = $this->currentDate->modify('last monday');
+        $weeks = [];
+
+        for ($week = 0; $week < 6; $week++) {
+            $weekDays = [];
+            for ($day = 0; $day < 7; $day++) {
+                $date = $start->modify(sprintf('+%d days', $week * 7 + $day));
+                $weekDays[] = [
+                    'day' => (int) $date->format('j'),
+                    'isCurrentMonth' => $date->format('m') === $this->currentDate->format('m'),
+                    'isToday' => $date->format('Y-m-d') === (new DateTimeImmutable())->format('Y-m-d'),
+                    'fullDate' => $date->format('Y-m-d'),
+                ];
+            }
+            $weeks[] = $weekDays;
+        }
+
+        return $weeks;
+    }
+
+    /**
+     * @return array<int, array<string, int|string|bool>>
+     */
+    public function daysOfMonth(): array
+    {
+        $days = [];
+        $daysInMonth = (int) $this->currentDate->format('t');
+        $weekdayFormatter = new IntlDateFormatter(
+            'de_DE',
+            IntlDateFormatter::NONE,
+            IntlDateFormatter::NONE,
+            $this->currentDate->getTimezone()->getName(),
+            IntlDateFormatter::GREGORIAN,
+            'EE'
+        );
+
+        for ($offset = 0; $offset < $daysInMonth; $offset++) {
+            $date = $this->currentDate->modify(sprintf('+%d days', $offset));
+
+            $days[] = [
+                'day' => (int) $date->format('j'),
+                'weekday' => $weekdayFormatter->format($date) ?: $date->format('D'),
+                'isToday' => $date->format('Y-m-d') === (new DateTimeImmutable())->format('Y-m-d'),
+                'date' => $date->format('Y-m-d'),
+            ];
+        }
+
+        return $days;
+    }
+}

--- a/src/Database.php
+++ b/src/Database.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace ModPMS;
+
+use PDO;
+use PDOException;
+use RuntimeException;
+
+class Database
+{
+    private static ?PDO $connection = null;
+
+    public static function getConnection(): PDO
+    {
+        if (self::$connection instanceof PDO) {
+            return self::$connection;
+        }
+
+        $configPath = __DIR__ . '/../config/database.php';
+
+        if (!is_readable($configPath)) {
+            throw new RuntimeException('Keine Datenbankkonfiguration gefunden. Bitte führen Sie den Installer aus.');
+        }
+
+        $config = include $configPath;
+
+        if (!is_array($config)) {
+            throw new RuntimeException('Die Datenbankkonfiguration ist ungültig.');
+        }
+
+        $driver = $config['driver'] ?? 'mysql';
+
+        if ($driver !== 'mysql') {
+            throw new RuntimeException(sprintf('Der Treiber "%s" wird derzeit nicht unterstützt.', (string) $driver));
+        }
+
+        $host = $config['host'] ?? null;
+        $database = $config['database'] ?? null;
+        $username = $config['username'] ?? null;
+        $password = $config['password'] ?? '';
+        $charset = $config['charset'] ?? 'utf8mb4';
+        $port = $config['port'] ?? '';
+
+        if ($host === null || $database === null || $username === null) {
+            throw new RuntimeException('Die Datenbankkonfiguration ist unvollständig.');
+        }
+
+        $dsn = sprintf(
+            'mysql:host=%s;%sdbname=%s;charset=%s',
+            $host,
+            $port !== '' ? sprintf('port=%s;', $port) : '',
+            $database,
+            $charset
+        );
+
+        try {
+            $pdo = new PDO($dsn, $username, $password, [
+                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+                PDO::ATTR_EMULATE_PREPARES => false,
+            ]);
+        } catch (PDOException $exception) {
+            throw new RuntimeException('Verbindung zur Datenbank fehlgeschlagen: ' . $exception->getMessage(), 0, $exception);
+        }
+
+        self::$connection = $pdo;
+
+        return self::$connection;
+    }
+}

--- a/src/RoomCategoryManager.php
+++ b/src/RoomCategoryManager.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace ModPMS;
+
+use PDO;
+
+class RoomCategoryManager
+{
+    private PDO $pdo;
+
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function all(): array
+    {
+        $statement = $this->pdo->query('SELECT id, name, description, capacity, status FROM room_categories ORDER BY name');
+
+        $categories = $statement ? $statement->fetchAll() : [];
+
+        return is_array($categories) ? $categories : [];
+    }
+
+    public function find(int $id): ?array
+    {
+        $statement = $this->pdo->prepare('SELECT id, name, description, capacity, status FROM room_categories WHERE id = :id');
+        $statement->execute(['id' => $id]);
+
+        $category = $statement->fetch();
+
+        return $category !== false ? $category : null;
+    }
+
+    /**
+     * @param array<string, mixed> $category
+     */
+    public function add(array $category): void
+    {
+        $statement = $this->pdo->prepare(
+            'INSERT INTO room_categories (name, description, capacity, status) VALUES (:name, :description, :capacity, :status)'
+        );
+
+        $statement->execute([
+            'name' => $category['name'],
+            'description' => $category['description'] !== '' ? $category['description'] : null,
+            'capacity' => (int) $category['capacity'],
+            'status' => $category['status'],
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $category
+     */
+    public function update(int $id, array $category): void
+    {
+        $statement = $this->pdo->prepare(
+            'UPDATE room_categories SET name = :name, description = :description, capacity = :capacity, status = :status WHERE id = :id'
+        );
+
+        $statement->execute([
+            'name' => $category['name'],
+            'description' => $category['description'] !== '' ? $category['description'] : null,
+            'capacity' => (int) $category['capacity'],
+            'status' => $category['status'],
+            'id' => $id,
+        ]);
+    }
+
+    public function delete(int $id): void
+    {
+        $statement = $this->pdo->prepare('DELETE FROM room_categories WHERE id = :id');
+        $statement->execute(['id' => $id]);
+    }
+}

--- a/src/RoomManager.php
+++ b/src/RoomManager.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace ModPMS;
+
+use PDO;
+
+class RoomManager
+{
+    private PDO $pdo;
+
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function all(): array
+    {
+        $statement = $this->pdo->query(
+            'SELECT r.id, r.room_number AS number, r.category_id, r.status, r.floor, r.notes, rc.name AS category_name
+             FROM rooms r
+             LEFT JOIN room_categories rc ON rc.id = r.category_id
+             ORDER BY CAST(r.room_number AS UNSIGNED), r.room_number'
+        );
+
+        $rooms = $statement ? $statement->fetchAll() : [];
+
+        return is_array($rooms) ? $rooms : [];
+    }
+
+    public function find(int $id): ?array
+    {
+        $statement = $this->pdo->prepare('SELECT id, room_number, category_id, status, floor, notes FROM rooms WHERE id = :id');
+        $statement->execute(['id' => $id]);
+
+        $room = $statement->fetch();
+
+        return $room !== false ? $room : null;
+    }
+
+    /**
+     * @param array<string, mixed> $room
+     */
+    public function create(array $room): void
+    {
+        $statement = $this->pdo->prepare(
+            'INSERT INTO rooms (room_number, category_id, status, floor, notes) VALUES (:room_number, :category_id, :status, :floor, :notes)'
+        );
+
+        $statement->execute([
+            'room_number' => $room['room_number'],
+            'category_id' => $room['category_id'],
+            'status' => $room['status'],
+            'floor' => $room['floor'] !== '' ? $room['floor'] : null,
+            'notes' => $room['notes'] !== '' ? $room['notes'] : null,
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $room
+     */
+    public function update(int $id, array $room): void
+    {
+        $statement = $this->pdo->prepare(
+            'UPDATE rooms SET room_number = :room_number, category_id = :category_id, status = :status, floor = :floor, notes = :notes WHERE id = :id'
+        );
+
+        $statement->execute([
+            'room_number' => $room['room_number'],
+            'category_id' => $room['category_id'],
+            'status' => $room['status'],
+            'floor' => $room['floor'] !== '' ? $room['floor'] : null,
+            'notes' => $room['notes'] !== '' ? $room['notes'] : null,
+            'id' => $id,
+        ]);
+    }
+
+    public function delete(int $id): void
+    {
+        $statement = $this->pdo->prepare('DELETE FROM rooms WHERE id = :id');
+        $statement->execute(['id' => $id]);
+    }
+}

--- a/src/SystemUpdater.php
+++ b/src/SystemUpdater.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace ModPMS;
+
+class SystemUpdater
+{
+    private string $projectRoot;
+    private string $branch;
+    private ?string $remoteUrl;
+
+    public function __construct(string $projectRoot, string $branch = 'main', ?string $remoteUrl = null)
+    {
+        $this->projectRoot = $projectRoot;
+        $this->branch = $branch;
+        $this->remoteUrl = $remoteUrl;
+    }
+
+    public function gitAvailable(): bool
+    {
+        if (!$this->canRunShellCommands()) {
+            return false;
+        }
+
+        $output = null;
+        $result = null;
+        @exec('which git', $output, $result);
+
+        return $result === 0 && !empty($output);
+    }
+
+    public function performUpdate(): array
+    {
+        if (!$this->canRunShellCommands()) {
+            return [
+                'success' => false,
+                'message' => 'Shell-Befehle sind auf dem Server deaktiviert. Bitte aktualisieren Sie manuell.',
+            ];
+        }
+
+        if (!$this->gitAvailable()) {
+            return [
+                'success' => false,
+                'message' => 'Git ist auf dem Server nicht verfügbar. Bitte manuell aktualisieren.',
+            ];
+        }
+
+        if (!$this->isGitRepository()) {
+            return [
+                'success' => false,
+                'message' => 'Das Installationsverzeichnis ist kein Git-Repository. Bitte klonen Sie das Projekt mit Git, bevor Sie den Updater verwenden.',
+            ];
+        }
+
+        $branch = $this->sanitizeBranch($this->branch);
+        if ($branch === null) {
+            return [
+                'success' => false,
+                'message' => 'Ungültiger Branch-Name für Updates.',
+            ];
+        }
+
+        $commands = [];
+
+        $remoteUrl = null;
+        if ($this->remoteUrl !== null && $this->remoteUrl !== '') {
+            $remoteUrl = $this->sanitizeRemoteUrl($this->remoteUrl);
+
+            if ($remoteUrl === null) {
+                return [
+                    'success' => false,
+                    'message' => 'Ungültige Repository-URL für Updates.',
+                ];
+            }
+        }
+
+        $hasOrigin = $this->remoteExists('origin');
+
+        if ($remoteUrl !== null) {
+            $remoteCommand = $hasOrigin
+                ? sprintf('git remote set-url origin %s', escapeshellarg($remoteUrl))
+                : sprintf('git remote add origin %s', escapeshellarg($remoteUrl));
+
+            $commands[] = $remoteCommand;
+        } elseif (!$hasOrigin) {
+            return [
+                'success' => false,
+                'message' => 'Es ist kein Remote-Repository konfiguriert. Bitte hinterlegen Sie eine Repository-URL in config/app.php.',
+            ];
+        }
+
+        $commands = array_merge($commands, [
+            'git fetch --prune origin',
+            sprintf('git reset --hard %s', escapeshellarg('origin/' . $branch)),
+            sprintf('git pull --ff-only origin %s', escapeshellarg($branch)),
+        ]);
+
+        $output = [];
+        foreach ($commands as $command) {
+            [$status, $cmdOutput] = $this->executeInProject($command);
+            $output[] = [
+                'command' => $command,
+                'status' => $status,
+                'output' => $cmdOutput,
+            ];
+
+            if ($status !== 0) {
+                return [
+                    'success' => false,
+                    'message' => 'Update fehlgeschlagen. Siehe Details.',
+                    'details' => $output,
+                ];
+            }
+        }
+
+        return [
+            'success' => true,
+            'message' => 'Update erfolgreich durchgeführt.',
+            'details' => $output,
+        ];
+    }
+
+    private function canRunShellCommands(): bool
+    {
+        if (!function_exists('exec')) {
+            return false;
+        }
+
+        $disabled = ini_get('disable_functions');
+        if ($disabled === false || $disabled === '') {
+            return true;
+        }
+
+        $disabledFunctions = array_map('trim', explode(',', $disabled));
+
+        return !in_array('exec', $disabledFunctions, true);
+    }
+
+    private function sanitizeBranch(string $branch): ?string
+    {
+        if ($branch === '') {
+            return null;
+        }
+
+        if (!preg_match('/^[A-Za-z0-9._\-\/]+$/', $branch)) {
+            return null;
+        }
+
+        return $branch;
+    }
+
+    private function sanitizeRemoteUrl(string $url): ?string
+    {
+        $url = trim($url);
+
+        if ($url === '') {
+            return null;
+        }
+
+        if (preg_match('/^[\w.+-]+@[\w.-]+:[\w.\/-]+$/', $url)) {
+            return $url;
+        }
+
+        $parts = parse_url($url);
+
+        if ($parts === false || !isset($parts['scheme'], $parts['host'])) {
+            return null;
+        }
+
+        if (!in_array($parts['scheme'], ['https', 'http', 'git'], true)) {
+            return null;
+        }
+
+        return $url;
+    }
+
+    private function isGitRepository(): bool
+    {
+        $output = [];
+        $status = 0;
+        exec(sprintf('cd %s && git rev-parse --is-inside-work-tree 2>&1', escapeshellarg($this->projectRoot)), $output, $status);
+
+        return $status === 0 && isset($output[0]) && trim($output[0]) === 'true';
+    }
+
+    private function remoteExists(string $remote): bool
+    {
+        $output = [];
+        $status = 0;
+        exec(sprintf('cd %s && git remote get-url %s 2>&1', escapeshellarg($this->projectRoot), escapeshellarg($remote)), $output, $status);
+
+        return $status === 0;
+    }
+
+    /**
+     * @return array{0:int,1:array<int,string>}
+     */
+    private function executeInProject(string $command): array
+    {
+        $cmdOutput = [];
+        $status = 0;
+        exec(sprintf('cd %s && %s 2>&1', escapeshellarg($this->projectRoot), $command), $cmdOutput, $status);
+
+        return [$status, $cmdOutput];
+    }
+}

--- a/storage/room_categories.json
+++ b/storage/room_categories.json
@@ -1,0 +1,16 @@
+[
+    {
+        "id": 1,
+        "name": "Standard Doppelzimmer",
+        "description": "Gemütliches Doppelzimmer mit Queensize-Bett.",
+        "capacity": 2,
+        "status": "aktiv"
+    },
+    {
+        "id": 2,
+        "name": "Deluxe Suite",
+        "description": "Großzügige Suite mit Wohnzimmer und Balkon.",
+        "capacity": 4,
+        "status": "aktiv"
+    }
+]

--- a/storage/rooms.json
+++ b/storage/rooms.json
@@ -1,0 +1,23 @@
+[
+    {
+        "id": 101,
+        "number": "101",
+        "category_id": 1,
+        "name": "Standard Doppelzimmer 101",
+        "status": "frei"
+    },
+    {
+        "id": 102,
+        "number": "102",
+        "category_id": 1,
+        "name": "Standard Doppelzimmer 102",
+        "status": "belegt"
+    },
+    {
+        "id": 201,
+        "number": "201",
+        "category_id": 2,
+        "name": "Deluxe Suite 201",
+        "status": "frei"
+    }
+]


### PR DESCRIPTION
## Summary
- guard the web updater when shell execution is disabled, Git is unavailable, or the project is not a Git checkout
- normalise remote configuration by adding origin if needed and capturing command output for clearer errors
- document the new safeguards and bump the app metadata to version 1.0.8

## Testing
- php -l src/SystemUpdater.php
- php -l config/app.php
- php -l public/update.php

------
https://chatgpt.com/codex/tasks/task_e_68f4d03f15ec8333b9be7ac7180b7341