### PR TITLE
Fix document numbering gaps when validation fails

### DIFF
--- a/src/DocumentManager.php
+++ b/src/DocumentManager.php
@@ -242,12 +242,12 @@ class DocumentManager
             throw new RuntimeException('Bitte mindestens eine Position erfassen.');
         }
 
-        $documentNumber = $this->generateDocumentNumber($type);
-
         $recipientName = trim((string) ($data['recipient_name'] ?? ''));
         if ($recipientName === '') {
             throw new RuntimeException('Bitte einen Empfänger angeben.');
         }
+
+        $documentNumber = $this->generateDocumentNumber($type);
 
         return $this->persistDocument([
             'type' => $type,


### PR DESCRIPTION
## Summary
- defer document number generation in `DocumentManager::createDocument()` until after recipient validation so failed submissions do not consume sequence values

## Testing
- php -l src/DocumentManager.php

------
https://chatgpt.com/codex/tasks/task_e_68fd320923c083339245f0ed8094f2d1